### PR TITLE
Fixing missing username in Dockerfile's `useradd` command

### DIFF
--- a/docker/templates/latest/Dockerfile
+++ b/docker/templates/latest/Dockerfile
@@ -64,7 +64,7 @@ COPY ./killbill.sh /etc/init.d/killbill.sh
 RUN chmod +x /etc/init.d/killbill.sh
 
 # Add admin user with sudo access
-RUN useradd -d /home/admin -G sudo && echo "admin:admin" | chpasswd
+RUN useradd -d /home/admin -G sudo admin && echo "admin:admin" | chpasswd
 
 # Export config and plugins directory
 VOLUME $KILLBILL_CONFIG $KILLBILL_HOME


### PR DESCRIPTION
Trying to build using the latest Dockerfile failed for me because `useradd` was missing the `admin` username
