### PR TITLE
Some fixes for local development instructions

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -110,7 +110,7 @@ It becomes fairly easy to start Kill Bill locally on your laptop. For example le
 1. Start the mysql container:
 
   ```
-  docker run -tid --name db -p 3306:3306 -e MYSQL_ROOT_PASSWORD=root mariadb
+  docker run -tid --name db -p 3306:3306 -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=killbill mariadb
   ```
 
 2. Configure the database:
@@ -118,11 +118,21 @@ It becomes fairly easy to start Kill Bill locally on your laptop. For example le
   ```
   echo "set global binlog_format = 'ROW'" | mysql -h $(docker-machine ip default) -uroot -p
   ```
-  And then create the database `killbill_0_16_0` and add the DDLs:
+  And then add the DDLs:
 
   * Kill Bill [DDL](http://docs.killbill.io/0.16/ddl.sql)
+
+    ```curl http://docs.killbill.io/0.16/ddl.sql | mysql -h $(docker-machine ip default) -Dkillbill -uroot -p```
+
   * Analytics [DDL](https://github.com/killbill/killbill-analytics-plugin/blob/master/src/main/resources/org/killbill/billing/plugin/analytics/ddl.sql)
+
+    ```curl https://raw.githubusercontent.com/killbill/killbill-analytics-plugin/master/src/main/resources/org/killbill/billing/plugin/analytics/ddl.sql | mysql -h $(docker-machine ip default) -D killbill -uroot -p```
+ 
   * Stripe [DDL](https://github.com/killbill/killbill-stripe-plugin/blob/master/db/ddl.sql)
+
+    ```curl https://raw.githubusercontent.com/killbill/killbill-stripe-plugin/master/db/ddl.sql | mysql -h $(docker-machine ip default) -D killbill -uroot -p```
+
+    Note that the `-e MYSQL_DATABASE=killbill` argument to `docker run` above took care of creating the `killbill` database for us. When deploying to a production scenario, you'll need to do that step explicitly.
 
 3. Start the killbill container with the two plugins `analytics` and `stripe`:
 
@@ -132,10 +142,10 @@ docker run -tid \
            -p 8080:8080 \
            -p 12345:12345 \
            --link db:dbserver \
-           -e KILLBILL_CONFIG_DAO_URL=jdbc:mysql://dbserver:3306/killbill_0_16_0 \
+           -e KILLBILL_CONFIG_DAO_URL=jdbc:mysql://dbserver:3306/killbill \
            -e KILLBILL_CONFIG_DAO_USER=root \
            -e KILLBILL_CONFIG_DAO_PASSWORD=root \
-           -e KILLBILL_CONFIG_OSGI_DAO_URL=jdbc:mysql://dbserver:3306/killbill_0_16_0 \
+           -e KILLBILL_CONFIG_OSGI_DAO_URL=jdbc:mysql://dbserver:3306/killbill \
            -e KILLBILL_CONFIG_OSGI_DAO_USER=root \
            -e KILLBILL_CONFIG_OSGI_DAO_PASSWORD=root \
            -e KILLBILL_PLUGIN_ANALYTICS=1 \

--- a/docker/README.md
+++ b/docker/README.md
@@ -122,15 +122,15 @@ It becomes fairly easy to start Kill Bill locally on your laptop. For example le
 
   * Kill Bill [DDL](http://docs.killbill.io/0.16/ddl.sql)
 
-    ```curl http://docs.killbill.io/0.16/ddl.sql | mysql -h $(docker-machine ip default) -Dkillbill -uroot -p```
+    ```curl -s http://docs.killbill.io/0.16/ddl.sql | mysql -h $(docker-machine ip default) -Dkillbill -uroot -p root```
 
   * Analytics [DDL](https://github.com/killbill/killbill-analytics-plugin/blob/master/src/main/resources/org/killbill/billing/plugin/analytics/ddl.sql)
 
-    ```curl https://raw.githubusercontent.com/killbill/killbill-analytics-plugin/master/src/main/resources/org/killbill/billing/plugin/analytics/ddl.sql | mysql -h $(docker-machine ip default) -D killbill -uroot -p```
+    ```curl -s https://raw.githubusercontent.com/killbill/killbill-analytics-plugin/master/src/main/resources/org/killbill/billing/plugin/analytics/ddl.sql | mysql -h $(docker-machine ip default) -D killbill -uroot -p root```
  
   * Stripe [DDL](https://github.com/killbill/killbill-stripe-plugin/blob/master/db/ddl.sql)
 
-    ```curl https://raw.githubusercontent.com/killbill/killbill-stripe-plugin/master/db/ddl.sql | mysql -h $(docker-machine ip default) -D killbill -uroot -p```
+    ```curl -s https://raw.githubusercontent.com/killbill/killbill-stripe-plugin/master/db/ddl.sql | mysql -h $(docker-machine ip default) -D killbill -uroot -p root```
 
     Note that the `-e MYSQL_DATABASE=killbill` argument to `docker run` above took care of creating the `killbill` database for us. When deploying to a production scenario, you'll need to do that step explicitly.
 


### PR DESCRIPTION
The local development instructions in `docker/README.md` didn't work as provided because

1. The mariadb Docker image doesn't create a database by default, and it was easy to overlook the instruction to create the `killbill` database.
2. The analytics and stripe DDLs don't specify a database, so they fail without specifying the DB on the mysql command line.
3. The instructions to create a database named `killbill_0_16_0` conflict with the main DDL's `use killbill` statement.

I fixed these by adding the `-e MYSQL_DATABASE=killbill` argument to the mariadb container, specifying the `-D killbill` argument to subsequent runs of the mysql client, and changing the Kill Bill container's environment to point back at the `killbill` database instead of `killbill_0_16_0`.

Also I added instructions that can be copy/pasted for installing all three DDL's.