### PR TITLE
Corrected incorrect syntax in docker-compose expose property

### DIFF
--- a/docker/compose/docker-compose.kb.yml
+++ b/docker/compose/docker-compose.kb.yml
@@ -26,6 +26,6 @@ kaui:
 db:
   image: mariadb
   expose:
-    - "3306:3306"
+    - "3306"
   environment:
     - MYSQL_ROOT_PASSWORD=killbill


### PR DESCRIPTION
docker-compose puked on "3306:3306" as expose is expected to be  'PORT[/PROTOCOL]'
