### PR TITLE
Make sure we only look at sub-folders and inspecting fs for plugins

### DIFF
--- a/kpm/lib/kpm/inspector.rb
+++ b/kpm/lib/kpm/inspector.rb
@@ -101,7 +101,7 @@ module KPM
     end
 
     def get_entries(path)
-      Dir.entries(path).select { |v| v != '.' && v != '..' }
+      Dir.entries(path).select { |entry| entry != '.' && entry != '..' && File.directory?(File.join(path, entry)) }
     end
 
   end


### PR DESCRIPTION
Fixes error: "Not a directory @ dir_initialize - .../plugins/ruby/.DS_Store"