### PR TITLE
fix killbill DDL first time install version.

### DIFF
--- a/docker/compose/README.md
+++ b/docker/compose/README.md
@@ -29,7 +29,7 @@ A MariaDB container is automatically started, and can be accessed from the Kill 
 ```
 host> docker exec -ti kb_killbill_1 /bin/bash
 tomcat7@container:/var/lib/tomcat7$ mysql -h db -uroot -pkillbill -e 'create database killbill; create database kaui'
-tomcat7@container:/var/lib/tomcat7$ curl -s http://docs.killbill.io/0.16/ddl.sql | mysql -h db -uroot -pkillbill killbill
+tomcat7@container:/var/lib/tomcat7$ curl -s http://docs.killbill.io/0.18/ddl.sql | mysql -h db -uroot -pkillbill killbill
 tomcat7@container:/var/lib/tomcat7$ curl -s https://raw.githubusercontent.com/killbill/killbill-admin-ui/master/db/ddl.sql | mysql -h db -uroot -pkillbill kaui
 ```
 


### PR DESCRIPTION
Hi,

I tried to run the docker compose examples yesterday and I had some problems trying to log into kaui, the culprit was related to changes in the killbill sessions table.

I found that the README in the docker compose page was using an old version to install the DDL, the command uses version 0.16 but the docker :latest image installs 0.18.

This change only fix that minor version problem in the README.