### PR TITLE
Initial Ansible support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ logs/
 *.classpath
 *.settings
 *.project
+*.retry

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ logs/
 *.classpath
 *.settings
 *.project
-*.retry
+ansible/*.retry
+ansible/hosts

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,14 @@
+# Usage
+
+## killbill_facts
+
+```
+# Assume KPM is installed through Rubygems
+ansible <HOST_GROUP> -i <HOST_FILE> -m killbill_facts -a 'config_file=/path/to/kpm.yml'
+
+# Self-contained KPM installed
+ansible <HOST_GROUP> -i <HOST_FILE> -m killbill_facts -a 'config_file=/path/to/kpm.yml kpm_path=/path/to/kpm-0.5.2-linux-x86_64'
+
+# Without kpm.yml
+ansible <HOST_GROUP> -i <HOST_FILE> -m killbill_facts -a 'killbill_web_path=/path/to/apache-tomcat/webapps/ROOT bundles_dir=/var/tmp/bundles'
+```

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -21,12 +21,12 @@ Configuration:
 
 Tomcat will automatically be restarted is `catalina_home` is defined.
 
-## tomcat_ubuntu playbook
+## tomcat.yml playbook
 
-Example playbook on how to install Tomcat on Ubuntu:
+Example playbook on how to install Tomcat (Java is a pre-requisite):
 
 ```
-ansible-playbook -i <HOST_FILE> tomcat_ubuntu.yml
+ansible-playbook -i <HOST_FILE> tomcat.yml
 ansible-playbook -i <HOST_FILE> play.yml
 ```
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -19,6 +19,19 @@ Configuration:
 * [roles/killbill/templates/killbill.properties.j2](roles/killbill/templates/killbill.properties.j2) is the main Kill Bill configuration file
 * [roles/tomcat/templates/setenv.sh.j2](roles/tomcat/templates/setenv.sh.j2) defines JVM level system properties
 
+Tomcat will automatically be restarted is `catalina_home` is defined.
+
+## tomcat_ubuntu playbook
+
+Example playbook on how to install Tomcat on Ubuntu:
+
+```
+ansible-playbook -i <HOST_FILE> tomcat_ubuntu.yml
+ansible-playbook -i <HOST_FILE> play.yml
+```
+
+# Internals
+
 ## killbill_facts module
 
 ```

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,6 +1,12 @@
 # Usage
 
-## killbill_facts
+## play.yml playbook
+
+```
+ansible-playbook -i <HOST_FILE> play.yml
+```
+
+## killbill_facts module
 
 ```
 # Assume KPM is installed through Rubygems
@@ -12,3 +18,5 @@ ansible <HOST_GROUP> -i <HOST_FILE> -m killbill_facts -a 'config_file=/path/to/k
 # Without kpm.yml
 ansible <HOST_GROUP> -i <HOST_FILE> -m killbill_facts -a 'killbill_web_path=/path/to/apache-tomcat/webapps/ROOT bundles_dir=/var/tmp/bundles'
 ```
+
+Ansible requires the module file to start with `/usr/bin/ruby` to allow for shebang line substitution. If no Ruby interpreter is available at that path, you can configure it through `ansible_ruby_interpreter`, which is set per-host as an inventory variable associated with a host or group of hosts (e.g. `ansible_ruby_interpreter=/opt/kpm-0.5.2-linux-x86_64/lib/ruby/bin/ruby` in your host file).

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -6,6 +6,19 @@
 ansible-playbook -i <HOST_FILE> play.yml
 ```
 
+The playbook has several roles:
+
+* common: Ansible setup (defines `ansible_ruby_interpreter`)
+* tomcat: `$CATALINA_BASE` setup (does not install nor manage Tomcat itself)
+* kpm: KPM setup and installation
+* killbill: Kill Bill setup and installation
+
+Configuration:
+
+* [group_vars/all.yml](group_vars/all.yml) defines what to install (KPM version, Kill Bill version, plugins, etc.) and the main configuration options. This could be overridden in a child `group_vars` or even in `host_vars` (https://docs.ansible.com/ansible/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable)
+* [roles/killbill/templates/killbill.properties.j2](roles/killbill/templates/killbill.properties.j2) is the main Kill Bill configuration file
+* [roles/tomcat/templates/setenv.sh.j2](roles/tomcat/templates/setenv.sh.j2) defines JVM level system properties
+
 ## killbill_facts module
 
 ```

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -30,6 +30,15 @@ ansible-playbook -i <HOST_FILE> tomcat.yml
 ansible-playbook -i <HOST_FILE> play.yml
 ```
 
+## plugin.yml playbook
+
+Allow to restart a specific plugin
+
+For example to restart `adyen` plugin
+```
+ansible-playbook -i <HOST_FILE> plugin.yml --extra-vars "plugin_key=adyen"
+```
+
 # Internals
 
 ## killbill_facts module

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,0 +1,55 @@
+---
+nexus_url: https://oss.sonatype.org
+nexus_repository: releases
+
+kpm_install_dir: /opt
+kpm_version: 0.5.3
+kpm_path: "{{ kpm_install_dir }}/kpm-{{ kpm_version }}-linux-{{ ansible_architecture }}"
+
+catalina_base: /opt/apache-tomcat
+tomcat_owner: "{{ ansible_user_id }}"
+tomcat_group: root
+
+# Base directory for namespacing
+kb_install_dir: /opt/killbill
+# Configuration files (killbill.properties, JRuby files, etc.)
+kb_config_dir: "{{ kb_install_dir }}/config"
+# Kill Bill plugins and OSGI bundles
+kb_plugins_dir: "{{ kb_install_dir }}/bundles"
+# kpm.yml -- see https://github.com/killbill/killbill-cloud/tree/master/kpm
+kpm_yml:
+  killbill:
+    version: 0.18.10
+    webapp_path: "{{ catalina_base }}/webapps/ROOT.war"
+    nexus:
+      ssl_verify: false
+      url: "{{ nexus_url }}"
+      repository: "{{ nexus_repository }}"
+    plugins_dir: "{{ kb_plugins_dir }}"
+    plugins:
+      java:
+        - name: analytics
+      ruby:
+        - name: kpm
+
+# Kill Bill properties
+database_url: "jdbc:h2:file:{{ kb_config_dir }}/killbill;MODE=MYSQL;DB_CLOSE_DELAY=-1;MVCC=true;DB_CLOSE_ON_EXIT=FALSE"
+database_user: killbill
+database_password: killbill
+
+# Kill Bill properties -- recommended defaults
+database_connection_timeout: 100s
+database_max_active: 150
+database_min_idle: 5
+database_idle_max_age: 2m
+jvm_initial_memory: 4G
+jvm_max_memory: 4G
+jvm_jdwp_port: 12345
+jvm_jdwp_server: y
+jvm_cms_initiating_fraction_threshold: 50
+jvm_new_size: 600m
+jvm_max_new_size: 1900m
+jvm_survivor_ratio: 10
+jvm_jmx_port: 8000
+tomcat_port: 8080
+tomcat_max_threads: 150

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -6,6 +6,7 @@ kpm_install_dir: /opt
 kpm_version: 0.5.3
 kpm_path: "{{ kpm_install_dir }}/kpm-{{ kpm_version }}-linux-{{ ansible_architecture }}"
 
+catalina_home: /usr/share/tomcat
 catalina_base: /opt/apache-tomcat
 tomcat_owner: "{{ ansible_user_id }}"
 tomcat_group: root

--- a/ansible/library/killbill
+++ b/ansible/library/killbill
@@ -1,0 +1,32 @@
+#!/usr/bin/ruby
+# WANT_JSON
+
+require 'json'
+require 'logger'
+require 'stringio'
+
+data = {}
+File.open(ARGV[0]) do |fh|
+  data = JSON.parse(fh.read())
+end
+
+unless data['kpm_path'].nil?
+  ENV['GEM_PATH']="#{data['kpm_path']}/lib/vendor/ruby/2.2.0"
+  Gem.clear_paths
+end
+require 'kpm'
+
+# Temporary -- https://github.com/killbill/killbill-cloud/issues/91
+log = StringIO.new
+logger = Logger.new(log)
+logger.level = Logger::INFO
+
+kpm_yml = data['kpm_yml'].to_hash
+KPM::Installer.new(kpm_yml, logger).install(kpm_yml['force_download'], kpm_yml['verify_sha1'])
+
+result = {
+  'changed' => !(log.string =~ /Successful installation/).nil?,
+  'msg' => log.string
+}
+
+print JSON.dump(result)

--- a/ansible/library/killbill_facts
+++ b/ansible/library/killbill_facts
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+# WANT_JSON
+
+require 'json'
+require 'pathname'
+
+# Temporary -- https://github.com/killbill/killbill-cloud/issues/78
+def with_captured_stdout
+  require 'stringio'
+  old_stdout = $stdout
+  $stdout = StringIO.new
+  yield
+  JSON.parse($stdout.string.split("\n")[-1])
+ensure
+  $stdout = old_stdout
+end
+
+data = {}
+File.open(ARGV[0]) do |fh|
+  data = JSON.parse(fh.read())
+end
+
+unless data['kpm_path'].nil?
+  ENV['GEM_PATH']="#{data['kpm_path']}/lib/vendor/ruby/2.2.0"
+  Gem.clear_paths
+end
+require 'kpm'
+require 'kpm/version'
+
+kpm_facts = with_captured_stdout { KPM::System.new.information(data['bundles_dir'],
+                                                               true,
+                                                               data['config_file'],
+                                                               data['kaui_web_path'],
+                                                               data['killbill_web_path']) }
+
+result = {
+  'changed' => false,
+  'ansible_facts' => {
+    'kpm' => kpm_facts
+  }
+}
+
+print JSON.dump(result)

--- a/ansible/library/killbill_facts
+++ b/ansible/library/killbill_facts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/ruby
 # WANT_JSON
 
 require 'json'

--- a/ansible/library/killbill_plugin
+++ b/ansible/library/killbill_plugin
@@ -1,0 +1,64 @@
+#!/usr/bin/ruby
+# WANT_JSON
+
+# Read TASK input as json (WANT_JSON directive above)
+require 'json'
+data = {}
+File.open(ARGV[0]) do |fh|
+  data = JSON.parse(fh.read())
+end
+
+# Boilerplate code require in our ruby killbill module (depending of KPM)
+unless data['kpm_path'].nil?
+  ENV['GEM_PATH']="#{data['kpm_path']}/lib/vendor/ruby/2.2.0"
+  Gem.clear_paths
+end
+
+
+require 'kpm'
+require 'kpm/version'
+
+require 'killbill_client'
+
+# We expect KB to run on the local host on port 8080
+KillBillClient.url="http://127.0.0.1:8080"
+
+KillBillClient.username=data['username']
+KillBillClient.password=data['password']
+
+def format_res(input, changed, res, msg=nil)
+  {
+      'changed' => changed,
+      'msg' => {
+          'input' => input,
+          'res' => res,
+          'error' => msg
+      }
+  }
+end
+
+if data['plugin_cmd'] == 'LIST'
+
+  plugin_info = KillBillClient::Model::NodesInfo.nodes_info
+
+  # Simplify output to return basic KB plugin info for each node
+  filtered = plugin_info.inject({}) { |m, e| m[e.node_name] = e.plugins_info.select { |u| u.plugin_key }.map {|f| {"pluginKey" => f.plugin_key, "pluginName" => f.plugin_name, "version" => f.version, "state" => f.state }}; m  }
+  # Filter active if requested
+  filtered = filtered.select { |e| e["state"] == "RUNNING"} if data.key?('active_only') && data['active_only']
+
+  result = format_res(data, true, filtered)
+elsif data['plugin_cmd'] == 'RESTART'
+
+  if data['plugin_key']
+    KillBillClient::Model::NodesInfo.stop_plugin(data['plugin_key'], nil, [], data['local_node_only'])
+    plugin_info = KillBillClient::Model::NodesInfo.start_plugin(data['plugin_key'], nil, [], data['local_node_only'])
+    result = format_res(data, true, plugin_info)
+  else
+    result = format_res(data, false, [], "Missing argument plugin_key")
+  end
+else
+  result = format_res(data, true, nil, "Unknown command #{data['plugin_cmd']}")
+end
+
+print JSON.dump(result)
+

--- a/ansible/play.yml
+++ b/ansible/play.yml
@@ -1,11 +1,8 @@
 ---
 - name: Deploy Kill Bill
   hosts: all
-  vars:
-    kpm_install_dir: /opt
-    kpm_version: 0.5.3
-    # Unfortunately, we cannot use Jinja2 templates here
-    #ansible_ruby_interpreter: "{{ kpm_install_dir }}/kpm-{{ kpm_version }}-linux-{{ ansible_architecture }}/lib/ruby/bin/ruby"
-    ansible_ruby_interpreter: "/opt/kpm-0.5.3-linux-x86_64/lib/ruby/bin/ruby"
   roles:
+    - common
+    - tomcat
     - kpm
+    - killbill

--- a/ansible/play.yml
+++ b/ansible/play.yml
@@ -1,0 +1,11 @@
+---
+- name: Deploy Kill Bill
+  hosts: all
+  vars:
+    kpm_install_dir: /opt
+    kpm_version: 0.5.3
+    # Unfortunately, we cannot use Jinja2 templates here
+    #ansible_ruby_interpreter: "{{ kpm_install_dir }}/kpm-{{ kpm_version }}-linux-{{ ansible_architecture }}/lib/ruby/bin/ruby"
+    ansible_ruby_interpreter: "/opt/kpm-0.5.3-linux-x86_64/lib/ruby/bin/ruby"
+  roles:
+    - kpm

--- a/ansible/play.yml
+++ b/ansible/play.yml
@@ -6,3 +6,7 @@
     - tomcat
     - kpm
     - killbill
+  handlers:
+    - include: roles/tomcat/handlers/main.yml
+      # https://github.com/ansible/ansible/issues/18178
+      static: no

--- a/ansible/plugin.yml
+++ b/ansible/plugin.yml
@@ -4,22 +4,4 @@
   roles:
     - common
     - kpm
-  tasks:
-    - name: Plugin List
-      killbill_plugin:
-        plugin_cmd: LIST
-        kpm_path: "{{ kpm_path }}"
-        username: "{{ username | default('admin') }}"
-        password: "{{ password | default('password') }}"
-        active_only: "{{ active_only | default(false) }}"
-      tags: plugin_list
-
-    - name: Plugin Restart
-      killbill_plugin:
-        plugin_cmd: RESTART
-        kpm_path: "{{ kpm_path }}"
-        plugin_key: "{{ plugin_key }}"
-        username: "{{ username | default('admin') }}"
-        password: "{{ password | default('password') }}"
-        local_node_only: "{{ local_node_only | default(false) }}"
-      tags: plugin_restart
+    - plugins

--- a/ansible/plugin.yml
+++ b/ansible/plugin.yml
@@ -1,0 +1,25 @@
+---
+- name: Plugin Management
+  hosts: all
+  roles:
+    - common
+    - kpm
+  tasks:
+    - name: Plugin List
+      killbill_plugin:
+        plugin_cmd: LIST
+        kpm_path: "{{ kpm_path }}"
+        username: "{{ username | default('admin') }}"
+        password: "{{ password | default('password') }}"
+        active_only: "{{ active_only | default(false) }}"
+      tags: plugin_list
+
+    - name: Plugin Restart
+      killbill_plugin:
+        plugin_cmd: RESTART
+        kpm_path: "{{ kpm_path }}"
+        plugin_key: "{{ plugin_key }}"
+        username: "{{ username | default('admin') }}"
+        password: "{{ password | default('password') }}"
+        local_node_only: "{{ local_node_only | default(false) }}"
+      tags: plugin_restart

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: ansible_ruby_interpreter setup
+  set_fact: ansible_ruby_interpreter="{{ kpm_path }}/lib/ruby/bin/ruby"
+  tags: common

--- a/ansible/roles/killbill/tasks/main.yml
+++ b/ansible/roles/killbill/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: ensure Kill Bill dirs exist
+  sudo: true
+  file: path={{ item }} state=directory owner={{ tomcat_owner }} group={{ tomcat_group }}
+  with_items:
+    - "{{ kb_install_dir }}"
+    - "{{ kb_config_dir }}"
+    - "{{ kb_plugins_dir }}"
+  tags: kpm-install
+
+- name: generate Kill Bill properties file
+  sudo: true
+  template:
+    src: killbill.properties.j2
+    dest: "{{ kb_config_dir }}/killbill.properties"
+    mode: u=rw,g=r,o=r
+    owner: "{{ tomcat_owner }}"
+    group: "{{ tomcat_group }}"
+  tags: kpm-install
+
+- name: run KPM install
+  sudo: true
+  killbill:
+    kpm_path: "{{ kpm_path }}"
+    kpm_yml: "{{ kpm_yml }}"
+  tags: kpm-install

--- a/ansible/roles/killbill/tasks/main.yml
+++ b/ansible/roles/killbill/tasks/main.yml
@@ -16,6 +16,7 @@
     mode: u=rw,g=r,o=r
     owner: "{{ tomcat_owner }}"
     group: "{{ tomcat_group }}"
+  notify: "restart Tomcat"
   tags: kpm-install
 
 - name: run KPM install
@@ -23,4 +24,5 @@
   killbill:
     kpm_path: "{{ kpm_path }}"
     kpm_yml: "{{ kpm_yml }}"
+  notify: "restart Tomcat"
   tags: kpm-install

--- a/ansible/roles/killbill/templates/killbill.properties.j2
+++ b/ansible/roles/killbill/templates/killbill.properties.j2
@@ -1,0 +1,68 @@
+org.killbill.osgi.bundle.install.dir={{ kb_plugins_dir }}
+org.killbill.billing.osgi.bundles.jruby.conf.dir={{ kb_config_dir }}
+
+org.killbill.billing.osgi.dao.connectionTimeout={{ database_connection_timeout }}
+org.killbill.billing.osgi.dao.maxActive={{ database_max_active }}
+org.killbill.billing.osgi.dao.minIdle={{ database_min_idle }}
+org.killbill.billing.osgi.dao.idleMaxAge={{ database_idle_max_age }}
+org.killbill.billing.osgi.dao.url={{ database_url }}
+org.killbill.billing.osgi.dao.user={{ database_user }}
+org.killbill.billing.osgi.dao.password={{ database_password }}
+
+org.killbill.dao.connectionTimeout={{ database_connection_timeout }}
+org.killbill.dao.maxActive={{ database_max_active }}
+org.killbill.dao.minIdle={{ database_min_idle }}
+org.killbill.dao.idleMaxAge={{ database_idle_max_age }}
+org.killbill.dao.url={{ database_url }}
+org.killbill.dao.user={{ database_user }}
+org.killbill.dao.password={{ database_password }}
+
+org.killbill.jruby.context.scope=THREADSAFE
+
+org.killbill.notificationq.analytics.claimed=100
+org.killbill.notificationq.analytics.historyTableName=analytics_notifications_history
+org.killbill.notificationq.analytics.inMemory=false
+org.killbill.notificationq.analytics.max.failure.retry=3
+org.killbill.notificationq.analytics.notification.nbThreads=5
+org.killbill.notificationq.analytics.queue.capacity=30000
+org.killbill.notificationq.analytics.sleep=3000
+org.killbill.notificationq.analytics.sticky=true
+org.killbill.notificationq.analytics.tableName=analytics_notifications
+
+org.killbill.notificationq.main.claimed=100
+org.killbill.notificationq.main.inMemory=false
+org.killbill.notificationq.main.max.failure.retry=3
+org.killbill.notificationq.main.notification.nbThreads=10
+org.killbill.notificationq.main.sleep=70000
+org.killbill.notificationq.main.sticky=true
+
+org.killbill.payment.janitor.rate=5m
+org.killbill.payment.janitor.unknown.retries=1h,6h,17h
+org.killbill.payment.janitor.pending.retries=65m,3h,3h,5h,1d,1d,1d,1d
+
+org.killbill.payment.plugin.threads.nb=100
+org.killbill.payment.plugin.timeout=64s
+
+org.killbill.persistent.bus.external.claim.time=5m
+org.killbill.persistent.bus.external.inMemory=true
+org.killbill.persistent.bus.external.inflight.claimed=500
+org.killbill.persistent.bus.external.max.failure.retry=3
+org.killbill.persistent.bus.external.nbThreads=50
+org.killbill.persistent.bus.external.queue.capacity=1000000
+org.killbill.persistent.bus.external.sleep=0
+org.killbill.persistent.bus.external.sticky=true
+org.killbill.persistent.bus.external.useInflightQ=true
+
+org.killbill.persistent.bus.main.claim.time=5m
+org.killbill.persistent.bus.main.inMemory=false
+org.killbill.persistent.bus.main.inflight.claimed=500
+org.killbill.persistent.bus.main.max.failure.retry=3
+org.killbill.persistent.bus.main.nbThreads=50
+org.killbill.persistent.bus.main.queue.capacity=1000000
+org.killbill.persistent.bus.main.sleep=0
+org.killbill.persistent.bus.main.sticky=true
+org.killbill.persistent.bus.main.useInflightQ=true
+
+org.killbill.jaxrs.location.full.url=true
+
+org.killbill.server.test.mode=true

--- a/ansible/roles/kpm/tasks/main.yml
+++ b/ansible/roles/kpm/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: ensure KPM install dir exists
+  sudo: true
+  file:
+    path: "{{ kpm_install_dir }}"
+    state: directory
+  tags: kpm
+
+- name: install KPM
+  sudo: true
+  unarchive:
+    src: "{{ nexus_url | default('https://oss.sonatype.org/content/repositories/releases') }}/org/kill-bill/billing/installer/kpm/{{ kpm_version }}/kpm-{{ kpm_version }}-linux-{{ ansible_architecture }}.tar.gz"
+    remote_src: True
+    dest: "{{ kpm_install_dir }}"
+  tags: kpm
+
+- name: gather KPM facts
+  killbill_facts:
+    kpm_path: "{{ kpm_install_dir }}/kpm-{{ kpm_version }}-linux-{{ ansible_architecture }}"
+  tags: kpm
+

--- a/ansible/roles/kpm/tasks/main.yml
+++ b/ansible/roles/kpm/tasks/main.yml
@@ -9,13 +9,13 @@
 - name: install KPM
   sudo: true
   unarchive:
-    src: "{{ nexus_url | default('https://oss.sonatype.org/content/repositories/releases') }}/org/kill-bill/billing/installer/kpm/{{ kpm_version }}/kpm-{{ kpm_version }}-linux-{{ ansible_architecture }}.tar.gz"
+    src: "{{ nexus_url }}/content/repositories/{{ nexus_repository }}/org/kill-bill/billing/installer/kpm/{{ kpm_version }}/kpm-{{ kpm_version }}-linux-{{ ansible_architecture }}.tar.gz"
     remote_src: True
     dest: "{{ kpm_install_dir }}"
   tags: kpm
 
 - name: gather KPM facts
   killbill_facts:
-    kpm_path: "{{ kpm_install_dir }}/kpm-{{ kpm_version }}-linux-{{ ansible_architecture }}"
+    kpm_path: "{{ kpm_path }}"
   tags: kpm
 

--- a/ansible/roles/plugins/tasks/main.yml
+++ b/ansible/roles/plugins/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Plugin List
+  killbill_plugin:
+    plugin_cmd: LIST
+    kpm_path: "{{ kpm_path }}"
+    username: "{{ username | default('admin') }}"
+    password: "{{ password | default('password') }}"
+    active_only: "{{ active_only | default(false) }}"
+  tags: plugin-list
+
+- name: Plugin Restart
+  killbill_plugin:
+    plugin_cmd: RESTART
+    kpm_path: "{{ kpm_path }}"
+    username: "{{ username | default('admin') }}"
+    password: "{{ password | default('password') }}"
+    plugin_key: "{{ plugin_key }}"
+    local_node_only: "{{ local_node_only | default(false) }}"
+  tags: plugin-restart
+
+

--- a/ansible/roles/tomcat/handlers/main.yml
+++ b/ansible/roles/tomcat/handlers/main.yml
@@ -6,6 +6,8 @@
   listen: "restart Tomcat"
 
 - name: stop Tomcat (with PID file)
+  become: true
+  become_user: "{{ tomcat_owner }}"
   environment:
     CATALINA_BASE: "{{ catalina_base }}"
     CATALINA_PID: "{{ catalina_base }}/tomcat.pid"
@@ -17,6 +19,8 @@
   listen: "restart Tomcat"
 
 - name: stop Tomcat (without PID file)
+  become: true
+  become_user: "{{ tomcat_owner }}"
   environment:
     CATALINA_BASE: "{{ catalina_base }}"
   command: "{{ catalina_home }}/bin/catalina.sh stop 30 -force"
@@ -27,7 +31,8 @@
   listen: "restart Tomcat"
 
 - name: clean up Tomcat deployment files
-  sudo: true
+  become: true
+  become_user: "{{ tomcat_owner }}"
   file: path={{ catalina_base }}/{{ item }} state=absent
   with_items:
     - webapps/ROOT
@@ -36,6 +41,8 @@
   listen: "restart Tomcat"
 
 - name: start Tomcat
+  become: true
+  become_user: "{{ tomcat_owner }}"
   environment:
     CATALINA_BASE: "{{ catalina_base }}"
     CATALINA_PID: "{{ catalina_base }}/tomcat.pid"

--- a/ansible/roles/tomcat/handlers/main.yml
+++ b/ansible/roles/tomcat/handlers/main.yml
@@ -1,0 +1,46 @@
+---
+- name: check Tomcat PID file
+  stat: path="{{ catalina_base }}/tomcat.pid"
+  register: tomcat_pid
+  when: catalina_home is defined
+  listen: "restart Tomcat"
+
+- name: stop Tomcat (with PID file)
+  environment:
+    CATALINA_BASE: "{{ catalina_base }}"
+    CATALINA_PID: "{{ catalina_base }}/tomcat.pid"
+  command: "{{ catalina_home }}/bin/catalina.sh stop 30 -force"
+  ignore_errors: True
+  when:
+    - catalina_home is defined
+    - tomcat_pid.stat.exists == True
+  listen: "restart Tomcat"
+
+- name: stop Tomcat (without PID file)
+  environment:
+    CATALINA_BASE: "{{ catalina_base }}"
+  command: "{{ catalina_home }}/bin/catalina.sh stop 30 -force"
+  ignore_errors: True
+  when:
+    - catalina_home is defined
+    - tomcat_pid.stat.exists == False
+  listen: "restart Tomcat"
+
+- name: clean up Tomcat deployment files
+  sudo: true
+  file: path={{ catalina_base }}/{{ item }} state=absent
+  with_items:
+    - webapps/ROOT
+    - work/
+  when: catalina_home is defined
+  listen: "restart Tomcat"
+
+- name: start Tomcat
+  environment:
+    CATALINA_BASE: "{{ catalina_base }}"
+    CATALINA_PID: "{{ catalina_base }}/tomcat.pid"
+  command: "{{ catalina_home }}/bin/catalina.sh start"
+  async: 45
+  poll: 0
+  when: catalina_home is defined
+  listen: "restart Tomcat"

--- a/ansible/roles/tomcat/tasks/main.yml
+++ b/ansible/roles/tomcat/tasks/main.yml
@@ -1,12 +1,4 @@
 ---
-- name: clean up Tomcat deployment files
-  sudo: true
-  file: path={{ catalina_base }}/{{ item }} state=absent
-  with_items:
-    - webapps/ROOT
-    - work/
-  tags: tomcat
-
 - name: ensure Tomcat dirs exist
   sudo: true
   file: path={{ catalina_base }}/{{ item }} state=directory owner={{ tomcat_owner }} group={{ tomcat_group }}
@@ -37,4 +29,9 @@
       name: setenv.sh
       mode: u=rwx,g=rx,o=rx
       dest: "{{ catalina_base }}/bin"
+    - src: conf
+      name: web.xml
+      mode: u=rw,g=r,o=r
+      dest: "{{ catalina_base }}/conf"
+  notify: "restart Tomcat"
   tags: tomcat

--- a/ansible/roles/tomcat/tasks/main.yml
+++ b/ansible/roles/tomcat/tasks/main.yml
@@ -22,6 +22,10 @@
     group: "{{ tomcat_group }}"
   with_items:
     - src: conf
+      name: context.xml
+      mode: u=rw,g=r,o=r
+      dest: "{{ catalina_base }}/conf"
+    - src: conf
       name: server.xml
       mode: u=rw,g=r,o=r
       dest: "{{ catalina_base }}/conf"

--- a/ansible/roles/tomcat/tasks/main.yml
+++ b/ansible/roles/tomcat/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+- name: clean up Tomcat deployment files
+  sudo: true
+  file: path={{ catalina_base }}/{{ item }} state=absent
+  with_items:
+    - webapps/ROOT
+    - work/
+  tags: tomcat
+
+- name: ensure Tomcat dirs exist
+  sudo: true
+  file: path={{ catalina_base }}/{{ item }} state=directory owner={{ tomcat_owner }} group={{ tomcat_group }}
+  with_items:
+    - bin
+    - conf
+    - lib
+    - logs
+    - webapps
+    - work
+    - temp
+  tags: tomcat
+
+- name: generate Tomcat files
+  sudo: true
+  template:
+    src: "{{ item.src }}/{{ item.name }}.j2"
+    dest: "{{ item.dest }}/{{ item.name }}"
+    mode: "{{ item.mode }}"
+    owner: "{{ tomcat_owner }}"
+    group: "{{ tomcat_group }}"
+  with_items:
+    - src: conf
+      name: server.xml
+      mode: u=rw,g=r,o=r
+      dest: "{{ catalina_base }}/conf"
+    - src: conf
+      name: setenv.sh
+      mode: u=rwx,g=rx,o=rx
+      dest: "{{ catalina_base }}/bin"
+  tags: tomcat

--- a/ansible/roles/tomcat/templates/conf/context.xml.j2
+++ b/ansible/roles/tomcat/templates/conf/context.xml.j2
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Context unloadDelay="31000">
+</Context>

--- a/ansible/roles/tomcat/templates/conf/server.xml.j2
+++ b/ansible/roles/tomcat/templates/conf/server.xml.j2
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='utf-8'?>
+<Server port="8005" shutdown="SHUTDOWN">
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <Service name="Catalina">
+    <Executor name="tomcatThreadPool"
+              namePrefix="catalina-exec-"
+              maxThreads="{{ tomcat_max_threads }}"
+              maxIdleTime="30000"
+              minSpareThreads="4" />
+
+    <Connector executor="tomcatThreadPool"
+               port="{{ tomcat_port }}"
+               protocol="HTTP/1.1"
+               connectionTimeout="20000" />
+
+    <Engine name="Catalina" defaultHost="localhost">
+      <Host name="localhost"
+            appBase="webapps"
+            unpackWARs="true"
+            autoDeploy="true">
+
+        <Valve className="org.apache.catalina.valves.AccessLogValve"
+               directory="logs"
+               prefix="localhost_access_log."
+               suffix=".txt"
+               pattern="%h %l %u %t &quot;%m %U&quot; %s %b %D" />
+
+        <Valve className="org.apache.catalina.valves.rewrite.RewriteValve" />
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/ansible/roles/tomcat/templates/conf/server.xml.j2
+++ b/ansible/roles/tomcat/templates/conf/server.xml.j2
@@ -21,7 +21,7 @@
       <Host name="localhost"
             appBase="webapps"
             unpackWARs="true"
-            autoDeploy="true">
+            autoDeploy="false"><!-- Disable autoDeploy to avoid restarts when running KPM install -->
 
         <Valve className="org.apache.catalina.valves.AccessLogValve"
                directory="logs"

--- a/ansible/roles/tomcat/templates/conf/setenv.sh.j2
+++ b/ansible/roles/tomcat/templates/conf/setenv.sh.j2
@@ -1,48 +1,48 @@
 # JVM Options
-JAVA_OPTS="-server
-           -showversion
-           -XX:+PrintCommandLineFlags
-           -XX:+HeapDumpOnOutOfMemoryError
-           -XX:HeapDumpPath={{ catalina_base }}/logs/
-           -XX:+UseCodeCacheFlushing
-           -Xms{{ jvm_initial_memory }}
-           -Xmx{{ jvm_max_memory }}
-           -Xrunjdwp:transport=dt_socket,server={{ jvm_jdwp_server }},suspend=n,address={{ jvm_jdwp_port }}
-           -XX:+CMSClassUnloadingEnabled
-           -XX:-OmitStackTraceInFastThrow
-           -XX:+UseParNewGC
-           -XX:+UseConcMarkSweepGC
-           -XX:+CMSConcurrentMTEnabled
-           -XX:+ScavengeBeforeFullGC
-           -XX:+CMSScavengeBeforeRemark
-           -XX:+CMSParallelRemarkEnabled
-           -XX:+UseCMSInitiatingOccupancyOnly
-           -XX:CMSInitiatingOccupancyFraction={{ jvm_cms_initiating_fraction_threshold }}
-           -XX:NewSize={{ jvm_new_size }}
-           -XX:MaxNewSize={{ jvm_max_new_size }}
-           -XX:SurvivorRatio={{ jvm_survivor_ratio }}
-           -XX:+DisableExplicitGC
-           -Xloggc:{{ catalina_base }}/logs/gc.log
-           -XX:+PrintGCApplicationConcurrentTime
-           -XX:+PrintGCApplicationStoppedTime
-           -XX:+PrintGCDateStamps
-           -XX:+PrintGCDetails
-           -XX:+PrintTenuringDistribution
-           -XX:+UseGCLogFileRotation
-           -XX:NumberOfGCLogFiles=14
-           -XX:GCLogFileSize=100M"
+CATALINA_OPTS="-server
+               -showversion
+               -XX:+PrintCommandLineFlags
+               -XX:+HeapDumpOnOutOfMemoryError
+               -XX:HeapDumpPath={{ catalina_base }}/logs/
+               -XX:+UseCodeCacheFlushing
+               -Xms{{ jvm_initial_memory }}
+               -Xmx{{ jvm_max_memory }}
+               -Xrunjdwp:transport=dt_socket,server={{ jvm_jdwp_server }},suspend=n,address={{ jvm_jdwp_port }}
+               -XX:+CMSClassUnloadingEnabled
+               -XX:-OmitStackTraceInFastThrow
+               -XX:+UseParNewGC
+               -XX:+UseConcMarkSweepGC
+               -XX:+CMSConcurrentMTEnabled
+               -XX:+ScavengeBeforeFullGC
+               -XX:+CMSScavengeBeforeRemark
+               -XX:+CMSParallelRemarkEnabled
+               -XX:+UseCMSInitiatingOccupancyOnly
+               -XX:CMSInitiatingOccupancyFraction={{ jvm_cms_initiating_fraction_threshold }}
+               -XX:NewSize={{ jvm_new_size }}
+               -XX:MaxNewSize={{ jvm_max_new_size }}
+               -XX:SurvivorRatio={{ jvm_survivor_ratio }}
+               -XX:+DisableExplicitGC
+               -Xloggc:{{ catalina_base }}/logs/gc.log
+               -XX:+PrintGCApplicationConcurrentTime
+               -XX:+PrintGCApplicationStoppedTime
+               -XX:+PrintGCDateStamps
+               -XX:+PrintGCDetails
+               -XX:+PrintTenuringDistribution
+               -XX:+UseGCLogFileRotation
+               -XX:NumberOfGCLogFiles=14
+               -XX:GCLogFileSize=100M"
 
 # Java Properties
-export JAVA_OPTS="$JAVA_OPTS
-                  -Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true
-                  -Dcom.sun.management.jmxremote=true
-                  -Dcom.sun.management.jmxremote.authenticate=false
-                  -Dcom.sun.management.jmxremote.port={{ jvm_jmx_port }}
-                  -Dcom.sun.management.jmxremote.rmi.port={{ jvm_jmx_port }}
-                  -Dcom.sun.management.jmxremote.ssl=false
-                  -Djava.rmi.server.hostname={{ inventory_hostname }}
-                  -Djava.security.egd=file:/dev/./urandom
-                  -Djruby.compile.invokedynamic=false
-                  -Dlog4jdbc.sqltiming.error.threshold=1000
-                  -Dorg.killbill.queue.creator.name={{ inventory_hostname }}
-                  -Dorg.killbill.server.properties=file://{{ kb_config_dir }}/killbill.properties"
+export CATALINA_OPTS="$CATALINA_OPTS
+                      -Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true
+                      -Dcom.sun.management.jmxremote=true
+                      -Dcom.sun.management.jmxremote.authenticate=false
+                      -Dcom.sun.management.jmxremote.port={{ jvm_jmx_port }}
+                      -Dcom.sun.management.jmxremote.rmi.port={{ jvm_jmx_port }}
+                      -Dcom.sun.management.jmxremote.ssl=false
+                      -Djava.rmi.server.hostname={{ inventory_hostname }}
+                      -Djava.security.egd=file:/dev/./urandom
+                      -Djruby.compile.invokedynamic=false
+                      -Dlog4jdbc.sqltiming.error.threshold=1000
+                      -Dorg.killbill.queue.creator.name={{ inventory_hostname }}
+                      -Dorg.killbill.server.properties=file://{{ kb_config_dir }}/killbill.properties"

--- a/ansible/roles/tomcat/templates/conf/setenv.sh.j2
+++ b/ansible/roles/tomcat/templates/conf/setenv.sh.j2
@@ -1,0 +1,48 @@
+# JVM Options
+JAVA_OPTS="-server
+           -showversion
+           -XX:+PrintCommandLineFlags
+           -XX:+HeapDumpOnOutOfMemoryError
+           -XX:HeapDumpPath={{ catalina_base }}/logs/
+           -XX:+UseCodeCacheFlushing
+           -Xms{{ jvm_initial_memory }}
+           -Xmx{{ jvm_max_memory }}
+           -Xrunjdwp:transport=dt_socket,server={{ jvm_jdwp_server }},suspend=n,address={{ jvm_jdwp_port }}
+           -XX:+CMSClassUnloadingEnabled
+           -XX:-OmitStackTraceInFastThrow
+           -XX:+UseParNewGC
+           -XX:+UseConcMarkSweepGC
+           -XX:+CMSConcurrentMTEnabled
+           -XX:+ScavengeBeforeFullGC
+           -XX:+CMSScavengeBeforeRemark
+           -XX:+CMSParallelRemarkEnabled
+           -XX:+UseCMSInitiatingOccupancyOnly
+           -XX:CMSInitiatingOccupancyFraction={{ jvm_cms_initiating_fraction_threshold }}
+           -XX:NewSize={{ jvm_new_size }}
+           -XX:MaxNewSize={{ jvm_max_new_size }}
+           -XX:SurvivorRatio={{ jvm_survivor_ratio }}
+           -XX:+DisableExplicitGC
+           -Xloggc:{{ catalina_base }}/logs/gc.log
+           -XX:+PrintGCApplicationConcurrentTime
+           -XX:+PrintGCApplicationStoppedTime
+           -XX:+PrintGCDateStamps
+           -XX:+PrintGCDetails
+           -XX:+PrintTenuringDistribution
+           -XX:+UseGCLogFileRotation
+           -XX:NumberOfGCLogFiles=14
+           -XX:GCLogFileSize=100M"
+
+# Java Properties
+export JAVA_OPTS="$JAVA_OPTS
+                  -Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true
+                  -Dcom.sun.management.jmxremote=true
+                  -Dcom.sun.management.jmxremote.authenticate=false
+                  -Dcom.sun.management.jmxremote.port={{ jvm_jmx_port }}
+                  -Dcom.sun.management.jmxremote.rmi.port={{ jvm_jmx_port }}
+                  -Dcom.sun.management.jmxremote.ssl=false
+                  -Djava.rmi.server.hostname={{ inventory_hostname }}
+                  -Djava.security.egd=file:/dev/./urandom
+                  -Djruby.compile.invokedynamic=false
+                  -Dlog4jdbc.sqltiming.error.threshold=1000
+                  -Dorg.killbill.queue.creator.name={{ inventory_hostname }}
+                  -Dorg.killbill.server.properties=file://{{ kb_config_dir }}/killbill.properties"

--- a/ansible/roles/tomcat/templates/conf/web.xml.j2
+++ b/ansible/roles/tomcat/templates/conf/web.xml.j2
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+                      http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+  version="3.0">
+  <!-- ================== Built In Servlet Definitions ==================== -->
+  <servlet>
+      <servlet-name>default</servlet-name>
+      <servlet-class>org.apache.catalina.servlets.DefaultServlet</servlet-class>
+      <init-param>
+          <param-name>debug</param-name>
+          <param-value>0</param-value>
+      </init-param>
+      <init-param>
+          <param-name>listings</param-name>
+          <param-value>false</param-value>
+      </init-param>
+      <load-on-startup>1</load-on-startup>
+  </servlet>
+
+  <!-- ================ Built In Servlet Mappings ========================= -->
+  <servlet-mapping>
+      <servlet-name>default</servlet-name>
+      <url-pattern>/</url-pattern>
+  </servlet-mapping>
+
+  <!-- ===================== Default MIME Type Mappings =================== -->
+  <mime-mapping>
+      <extension>css</extension>
+      <mime-type>text/css</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+      <extension>html</extension>
+      <mime-type>text/html</mime-type>
+  </mime-mapping>
+  <mime-mapping>
+      <extension>js</extension>
+      <mime-type>application/javascript</mime-type>
+  </mime-mapping>
+</web-app>

--- a/ansible/tomcat.yml
+++ b/ansible/tomcat.yml
@@ -1,17 +1,13 @@
 ---
-- name: Deploy Tomcat on Ubuntu
+- name: Deploy Tomcat
   hosts: all
   vars:
     tomcat_version: 8.5.16
     tomcat_install_dir: /opt
     tomcat_owner: tomcat
     tomcat_group: tomcat
-  remote_user: root
   become: yes
-  become_method: sudo
   tasks:
-    - name: install Java
-      apt: name=default-jdk
     - name: add Tomcat group
       group: name="{{ tomcat_group }}"
     - name: add Tomcat user

--- a/ansible/tomcat_restart.yml
+++ b/ansible/tomcat_restart.yml
@@ -1,0 +1,10 @@
+---
+- name: Restart Tomcat
+  hosts: all
+  tasks:
+    - name: restart Tomcat
+      debug: msg="restarting Tomcat"
+      changed_when: true
+      notify: "restart Tomcat"
+  handlers:
+    - include: roles/tomcat/handlers/main.yml

--- a/ansible/tomcat_ubuntu.yml
+++ b/ansible/tomcat_ubuntu.yml
@@ -1,0 +1,29 @@
+---
+- name: Deploy Tomcat on Ubuntu
+  hosts: all
+  vars:
+    tomcat_version: 8.5.16
+    tomcat_install_dir: /opt
+    tomcat_owner: tomcat
+    tomcat_group: tomcat
+  remote_user: root
+  become: yes
+  become_method: sudo
+  tasks:
+    - name: install Java
+      apt: name=default-jdk
+    - name: add Tomcat group
+      group: name="{{ tomcat_group }}"
+    - name: add Tomcat user
+      user: name="{{ tomcat_owner }}" group="{{ tomcat_group }}" home=/usr/share/tomcat createhome=no
+    - name: ensure Tomcat install dir exists
+      file: path="{{ tomcat_install_dir }}" state=directory
+    - name: install Tomcat
+      unarchive:
+        src: "http://archive.apache.org/dist/tomcat/tomcat-8/v{{ tomcat_version }}/bin/apache-tomcat-{{ tomcat_version }}.tar.gz"
+        remote_src: True
+        dest: "{{ tomcat_install_dir }}"
+        owner: "{{ tomcat_owner }}"
+        group: "{{ tomcat_group }}"
+    - name: symlink install directory
+      file: src="{{ tomcat_install_dir }}/apache-tomcat-{{ tomcat_version }}" path=/usr/share/tomcat state=link


### PR DESCRIPTION
Created a PR mostly to track our discussions:

* Consider publishing roles through Ansible Galaxy.
* Re-consider using handlers, as it makes it harder to use them directly. For Tomcat, it's also questionable whether we would ever deploy without restarting it (is it safe enough nowadays to just restart plugins?).
* Consider using these playbooks to build the Docker images.
* Load balancer support has been improved:
  * introduced the `org.killbill.server.shutdownDelay` property (to avoid unnecessary `sleep` before stop).
  * healthcheck can be manipulated through HTTP APIs (not yet integrated in the playbook).

@andrenpaes feel free to update what I've missed.