### PR TITLE
ansible: Flyway support

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -58,6 +58,18 @@ Example playbook on how to install Tomcat (Java is a pre-requisite):
 ansible-playbook -i <HOST_FILE> tomcat.yml
 ```
 
+## flyway.yml playbook
+
+Playbook to manage Kill Bill (and its plugins) migrations.
+
+Assuming Kill Bill is installed locally (`/var/lib/tomcat/webapps/ROOT.war` by default) and your `kpm.yml` (`/var/lib/killbill/kpm.yml` by default) points to the **new** version of Kill Bill:
+
+```
+ansible-playbook -i localhost, -e ansible_connection=local -e gh_token=XXX flyway.yml
+```
+
+This will install Flyway, fetch all migrations and prompt the user whether they should be applied.
+
 ## plugin.yml playbook
 
 Allow to restart a specific plugin

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -3,22 +3,27 @@ nexus_url: https://oss.sonatype.org
 nexus_repository: releases
 
 kpm_install_dir: /opt
-kpm_version: 0.6.5
+kpm_version: 0.7.1
 kpm_path: "{{ kpm_install_dir }}/kpm-{{ kpm_version }}-linux-{{ ansible_architecture }}"
 
 catalina_home: /usr/share/tomcat
-catalina_base: /opt/apache-tomcat
-tomcat_owner: "{{ ansible_user_id }}"
-tomcat_group: root
+catalina_base: /var/lib/tomcat
+tomcat_owner: tomcat
+tomcat_group: tomcat
 
 tomcat_foreground: false
 
 # Base directory for namespacing
-kb_install_dir: /opt/killbill
+kb_install_dir: /var/lib/killbill
 # Configuration files (killbill.properties, JRuby files, etc.)
 kb_config_dir: "{{ kb_install_dir }}/config"
 # Kill Bill plugins and OSGI bundles
 kb_plugins_dir: "{{ kb_install_dir }}/bundles"
+# kpm.yml file
+kpm_yml: "{{ kb_install_dir }}/kpm.yml"
+
+flyway_install_dir: /opt
+flyway: java -jar {{ flyway_install_dir }}/killbill-flyway.jar -url='{{ lookup('env','KILLBILL_DAO_URL') }}' -user={{ lookup('env','KILLBILL_DAO_USER') }} -password={{ lookup('env','KILLBILL_DAO_PASSWORD') }}
 
 # Extra JVM properties (e.g. -Dlogback.configurationFile={{ kb_config_dir }}/logback.xml)
 kaui_system_properties: ''

--- a/ansible/library/killbill_facts
+++ b/ansible/library/killbill_facts
@@ -17,10 +17,10 @@ require 'kpm'
 require 'kpm/version'
 
 kpm_facts = KPM::System.new.information(data['bundles_dir'],
-                                                               true,
-                                                               data['config_file'],
-                                                               data['kaui_web_path'],
-                                                               data['killbill_web_path'])
+                                        true,
+                                        data['config_file'],
+                                        data['kaui_web_path'],
+                                        data['killbill_web_path'])
 
 result = {
   'changed' => false,

--- a/ansible/library/killbill_migrations
+++ b/ansible/library/killbill_migrations
@@ -5,17 +5,6 @@ require 'json'
 require 'pathname'
 require 'set'
 
-# Temporary -- https://github.com/killbill/killbill-cloud/issues/78
-def with_captured_stdout
-  require 'stringio'
-  old_stdout = $stdout
-  $stdout = StringIO.new
-  yield
-  JSON.parse($stdout.string.split("\n")[-1])
-ensure
-  $stdout = old_stdout
-end
-
 data = {}
 File.open(ARGV[0]) do |fh|
   data = JSON.parse(fh.read())
@@ -28,12 +17,20 @@ end
 require 'kpm'
 require 'kpm/version'
 
-kpm_facts = with_captured_stdout { KPM::System.new.information(data['bundles_dir'],
-                                                               true,
-                                                               data['config_file'],
-                                                               data['kaui_web_path'],
-                                                               data['killbill_web_path']) }
+kpm_facts = KPM::System.new.information(data['bundles_dir'],
+                                        true,
+                                        data['config_file'],
+                                        data['kaui_web_path'],
+                                        data['killbill_web_path'])
 
+require 'json'
+kpm_facts = JSON.parse(kpm_facts)
+
+require 'yaml'
+kpm_yml = data['kpm_yml']
+if kpm_yml.is_a?(String)
+  kpm_yml = YAML::load_file(data['kpm_yml'])
+end
 
 errors = []
 all_migrations = {
@@ -44,6 +41,35 @@ all_migrations = {
   }
 }
 
+logger = Logger.new(STDOUT)
+logger.level = Logger::INFO
+
+# Core migrations
+kb_from_version = kpm_facts['killbill_information']['killbill']['version']
+kb_to_version = kpm_yml['killbill']['version']
+all_migrations[:from] = kb_from_version
+all_migrations[:to] = kb_to_version
+
+if kb_from_version == 'not found'
+  errors << "killbill version not found"
+else
+  kb_from_tag = "killbill-#{kb_from_version}"
+
+  if kb_to_version.nil? || kb_to_version == 'LATEST'
+    kb_to_version = KPM::Installer.get_kb_latest_stable_version
+  end
+  kb_to_tag = "killbill-#{kb_to_version}"
+
+  migrations_dir = KPM::Migrations.new(kb_from_tag, kb_to_tag, "killbill/killbill", data['gh_token'], logger).save
+
+  all_migrations[:killbill] = {
+    :from_tag => kb_from_tag,
+    :to_tag => kb_to_tag,
+    :table => 'schema_version',
+    :dir => migrations_dir
+  } unless migrations_dir.nil?
+end
+
 # Plugins migrations
 kpm_facts['plugin_information'].each do |plugin_name, plugin_details|
   from_version_details = plugin_details['versions'].find { |v| v['is_default'] }
@@ -51,28 +77,43 @@ kpm_facts['plugin_information'].each do |plugin_name, plugin_details|
     errors << "#{plugin_name} disabled"
     next
   end
-
-  to_version_details = data['kpm_yml']['killbill']['plugins'][plugin_details['type']].find { |p| p['name'] == plugin_details['plugin_key'] }
-  if to_version_details.nil?
-    # TODO Should we remove it? Upgrade it nonetheless?
-    errors << "#{plugin_name} not scheduled to be installed"
+  from_version = from_version_details['version']
+  if from_version.nil?
+    errors << "Unable to retrieve current version for #{plugin_name}"
     next
   end
 
-  from_version = from_version_details['version']
+  to_version_details = kpm_yml['killbill']['plugins'][plugin_details['type']].find { |p| p['name'] == plugin_details['plugin_key'] }
+  if to_version_details.nil?
+    errors << "#{plugin_name} is not scheduled to be upgraded"
+    next
+  end
   to_version = to_version_details['version']
+  if to_version.nil?
+    _, _, _, _, to_version, _ = KPM::PluginsDirectory.lookup(to_version_details['name'], true, kb_to_version)
+    if to_version.nil? || to_version == 'LATEST'
+      errors << "#{plugin_name} isn't availble for upgrade"
+      next
+    end
+  end
 
   is_ruby = plugin_details['type'] == 'ruby'
   if is_ruby
     from_tag = "v#{from_version}"
-    to_tag = to_version.nil? ? nil : "v#{to_version}"
+    to_tag = "v#{to_version}"
   else
     from_tag = "#{plugin_details['artifact_id']}-#{from_version}"
-    to_tag = to_version.nil? ? nil : "#{plugin_details['artifact_id']}-#{to_version}"
+    to_tag = "#{plugin_details['artifact_id']}-#{to_version}"
   end
 
   repository = "killbill-#{plugin_details['artifact_id']}"
-  migrations_dir = KPM::Migrations.new(from_tag, to_tag, "killbill/#{repository}", data['gh_token']).save
+  begin
+    migrations_dir = KPM::Migrations.new(from_tag, to_tag, "killbill/#{repository}", data['gh_token'], logger).save
+  rescue OpenURI::HTTPError => e
+    errors << "#{plugin_name} isn't availble for upgrade"
+    next
+  end
+
   next if migrations_dir.nil?
 
   if is_ruby
@@ -90,26 +131,6 @@ kpm_facts['plugin_information'].each do |plugin_name, plugin_details|
       :dir => migrations_dir
     }
   end
-end
-
-# Core migrations
-kb_from_version = kpm_facts['killbill_information']['killbill']['version']
-if kb_from_version == 'not found'
-  errors << "killbill version not found"
-else
-  kb_from_tag = "killbill-#{kb_from_version}"
-
-  kb_to_version = data['kpm_yml']['killbill']['version']
-  kb_to_tag = kb_to_version.nil? || kb_to_version == 'LATEST' ? nil : "killbill-#{kb_to_version}"
-
-  migrations_dir = KPM::Migrations.new(kb_from_tag, kb_to_tag, "killbill/killbill", data['gh_token']).save
-
-  all_migrations[:killbill] = {
-    :from_tag => kb_from_tag,
-    :to_tag => kb_to_tag,
-    :table => 'schema_version',
-    :dir => migrations_dir
-    } unless migrations_dir.nil?
 end
 
 result = {

--- a/ansible/library/killbill_migrations
+++ b/ansible/library/killbill_migrations
@@ -51,7 +51,11 @@ all_migrations[:from] = kb_from_version
 all_migrations[:to] = kb_to_version
 
 if kb_from_version == 'not found'
-  errors << "killbill version not found"
+  print JSON.dump({
+                      'failed' => true,
+                      'msg'    => 'Unable to retrieve Kill Bill version'
+                  })
+  exit(1)
 else
   kb_from_tag = "killbill-#{kb_from_version}"
 

--- a/ansible/roles/kpm/tasks/main.yml
+++ b/ansible/roles/kpm/tasks/main.yml
@@ -6,11 +6,16 @@
     state: directory
   tags: kpm
 
+- name: check if KPM is already installed
+  stat:
+    path: "{{ kpm_path }}/kpm"
+  register: kpm_bin
+
 - name: install KPM
   become: true
   unarchive:
     src: "{{ nexus_url }}/content/repositories/{{ nexus_repository }}/org/kill-bill/billing/installer/kpm/{{ kpm_version }}/kpm-{{ kpm_version }}-linux-{{ ansible_architecture }}.tar.gz"
     remote_src: True
     dest: "{{ kpm_install_dir }}"
+  when: kpm_bin.stat.exists == False
   tags: kpm
-

--- a/ansible/roles/migrations/tasks/main.yml
+++ b/ansible/roles/migrations/tasks/main.yml
@@ -10,52 +10,46 @@
   register: migrations
   tags: migrations
 
+- name: ensure Kill Bill install dir exists
+  become: true
+  file: path={{ kb_install_dir }} state=directory owner={{ tomcat_owner }} group={{ tomcat_group }}
+  tags: migrations
+
 - name: install Flyway
   # maven_artifact module requires xml on the host
   get_url:
-    url: "{{ nexus_url }}/content/repositories/{{ nexus_repository }}/org/kill-bill/billing/killbill-util/0.18.11/killbill-util-0.18.11-flyway.jar"
+    url: "{{ nexus_url }}/content/repositories/{{ nexus_repository }}/org/kill-bill/billing/killbill-util/{{ migrations['migrations']['from'] }}/killbill-util-{{ migrations['migrations']['from'] }}-flyway.jar"
     dest: "{{ kb_install_dir }}/killbill-flyway.jar"
-  tags: [migrations, java_migrations]
+  tags: migrations
 
-- name: generate SQL migrations for Kill Bill and Java plugins
-  command: java -jar {{ kb_install_dir }}/killbill-flyway.jar -locations=filesystem:{{ item['dir'] }} -table={{ item['table'] }} -url='{{ database_url }}' -user={{ database_user }} -password={{ database_password }} dryRunMigrate
+- name: generate Flyway baseline tables
+  command: java -jar {{ kb_install_dir }}/killbill-flyway.jar -locations=filesystem:{{ item['dir'] }} -table={{ item['table'] }} -url='{{ lookup('env','KILLBILL_DAO_URL') }}' -user={{ lookup('env','KILLBILL_DAO_USER') }} -password={{ lookup('env','KILLBILL_DAO_PASSWORD') }} baseline
+  with_items:
+    - "{{ migrations['migrations']['killbill'] }}"
+    - "{{ migrations['migrations']['plugins']['java'] }}"
+  when: item['dir'] is defined
+  tags: migrations
+
+# We verify that all migrations can be generated before attempting to run them one by one
+- name: validate SQL migrations for Kill Bill and Java plugins
+  command: java -jar {{ kb_install_dir }}/killbill-flyway.jar -locations=filesystem:{{ item['dir'] }} -table={{ item['table'] }} -url='{{ lookup('env','KILLBILL_DAO_URL') }}' -user={{ lookup('env','KILLBILL_DAO_USER') }} -password={{ lookup('env','KILLBILL_DAO_PASSWORD') }} dryRunMigrate
   with_items:
     - "{{ migrations['migrations']['killbill'] }}"
     - "{{ migrations['migrations']['plugins']['java'] }}"
   when: item['dir'] is defined
   register: java_dry_run_migrations
-  tags: [migrations, java_migrations]
+  tags: migrations
 
-- name: SQL migrations for Kill Bill and Java plugins
-  debug: var=item.stdout_lines
-  with_items: "{{ java_dry_run_migrations.results }}"
-  when: item.stdout_lines is defined
-  tags: [migrations, java_migrations]
+# Run core migrations
+- include_tasks: migrate.yml
+  loop:
+    - "{{ migrations['migrations']['killbill'] }}"
+  loop_control:
+    loop_var: migration
 
-- block:
-  - name: wait for confirmation for Kill Bill and Java plugins
-    pause: prompt='Should I run these migrations? Press return to continue. Press Ctrl+c and then "a" to abort'
-    tags: [migrations, java_migrations]
+# Run plugin migrations
+- include_tasks: migrate.yml
+  loop: "{{ migrations['migrations']['plugins']['java']|flatten(levels=1) }}"
+  loop_control:
+    loop_var: migration
 
-  - name: run migrations for Kill Bill and Java plugins
-    command: java -jar {{ kb_install_dir }}/killbill-flyway.jar -locations=filesystem:{{ item['dir'] }} -table={{ item['table'] }} -url='{{ database_url }}' -user={{ database_user }} -password={{ database_password }} migrate
-    with_items:
-      - "{{ migrations['migrations']['killbill'] }}"
-      - "{{ migrations['migrations']['plugins']['java'] }}"
-    when: item['dir'] is defined
-    register: java_migrations
-    tags: [migrations, java_migrations]
-
-  - name: Flyway migrations output for Kill Bill and Java plugins
-    debug: var=item.stdout_lines
-    with_items: "{{ java_migrations.results }}"
-    when: item.stdout_lines is defined
-    tags: [migrations, java_migrations]
-
-  when: java_dry_run_migrations.stdout.find("BEGIN;\nCOMMIT;") != -1
-
-# TODO
-# - name: generate SQL migrations for Ruby plugins
-#   local_action: killbill-migration
-#   with_items: "{{ migrations['migrations']['plugins']['ruby'] }}"
-#   tags: [migrations, ruby_migrations]

--- a/ansible/roles/migrations/tasks/main.yml
+++ b/ansible/roles/migrations/tasks/main.yml
@@ -28,6 +28,9 @@
     - "{{ migrations['migrations']['killbill'] }}"
     - "{{ migrations['migrations']['plugins']['java'] }}"
   when: item['dir'] is defined
+  register: baselineout
+  failed_when: baselineout.rc != 0 and 'as it already contains migrations' not in baselineout.stderr
+  changed_when: "'already initialized with' not in baselineout.stdout and 'as it already contains migrations' not in baselineout.stderr"
   tags: migrations
 
 # We verify that all migrations can be generated before attempting to run them one by one

--- a/ansible/roles/migrations/tasks/main.yml
+++ b/ansible/roles/migrations/tasks/main.yml
@@ -10,20 +10,20 @@
   register: migrations
   tags: migrations
 
-- name: ensure Kill Bill install dir exists
+- name: ensure Flyway install dir exists
   become: true
-  file: path={{ kb_install_dir }} state=directory owner={{ tomcat_owner }} group={{ tomcat_group }}
+  file: path={{ flyway_install_dir }} state=directory owner={{ tomcat_owner }} group={{ tomcat_group }}
   tags: migrations
 
 - name: install Flyway
   # maven_artifact module requires xml on the host
   get_url:
     url: "{{ nexus_url }}/content/repositories/{{ nexus_repository }}/org/kill-bill/billing/killbill-util/{{ migrations['migrations']['from'] }}/killbill-util-{{ migrations['migrations']['from'] }}-flyway.jar"
-    dest: "{{ kb_install_dir }}/killbill-flyway.jar"
+    dest: "{{ flyway_install_dir }}/killbill-flyway.jar"
   tags: migrations
 
 - name: generate Flyway baseline tables
-  command: java -jar {{ kb_install_dir }}/killbill-flyway.jar -locations=filesystem:{{ item['dir'] }} -table={{ item['table'] }} -url='{{ lookup('env','KILLBILL_DAO_URL') }}' -user={{ lookup('env','KILLBILL_DAO_USER') }} -password={{ lookup('env','KILLBILL_DAO_PASSWORD') }} baseline
+  command: "{{ flyway }} -locations=filesystem:{{ item['dir'] }} -table={{ item['table'] }} baseline"
   with_items:
     - "{{ migrations['migrations']['killbill'] }}"
     - "{{ migrations['migrations']['plugins']['java'] }}"
@@ -35,7 +35,7 @@
 
 # We verify that all migrations can be generated before attempting to run them one by one
 - name: validate SQL migrations for Kill Bill and Java plugins
-  command: java -jar {{ kb_install_dir }}/killbill-flyway.jar -locations=filesystem:{{ item['dir'] }} -table={{ item['table'] }} -url='{{ lookup('env','KILLBILL_DAO_URL') }}' -user={{ lookup('env','KILLBILL_DAO_USER') }} -password={{ lookup('env','KILLBILL_DAO_PASSWORD') }} dryRunMigrate
+  command: "{{ flyway }} -locations=filesystem:{{ item['dir'] }} -table={{ item['table'] }} dryRunMigrate"
   with_items:
     - "{{ migrations['migrations']['killbill'] }}"
     - "{{ migrations['migrations']['plugins']['java'] }}"

--- a/ansible/roles/migrations/tasks/main.yml
+++ b/ansible/roles/migrations/tasks/main.yml
@@ -6,7 +6,7 @@
     kaui_web_path: "{{ catalina_base }}/webapps/ROOT.war"
     killbill_web_path: "{{ catalina_base }}/webapps/ROOT.war"
     kpm_yml: "{{ kpm_yml }}"
-    gh_token: "{{ gh_token }}"
+    gh_token: "{{ gh_token|default('') }}"
   register: migrations
   tags: migrations
 

--- a/ansible/roles/migrations/tasks/main.yml
+++ b/ansible/roles/migrations/tasks/main.yml
@@ -40,6 +40,7 @@
     - "{{ migrations['migrations']['killbill'] }}"
     - "{{ migrations['migrations']['plugins']['java'] }}"
   when: item['dir'] is defined
+  changed_when: False
   register: java_dry_run_migrations
   tags: migrations
 
@@ -49,10 +50,12 @@
     - "{{ migrations['migrations']['killbill'] }}"
   loop_control:
     loop_var: migration
+  when: migration['dir'] is defined
 
 # Run plugin migrations
 - include_tasks: migrate.yml
   loop: "{{ migrations['migrations']['plugins']['java']|flatten(levels=1) }}"
   loop_control:
     loop_var: migration
+  when: migration['dir'] is defined
 

--- a/ansible/roles/migrations/tasks/migrate.yml
+++ b/ansible/roles/migrations/tasks/migrate.yml
@@ -1,29 +1,38 @@
 - name: generate SQL migration
   command: java -jar {{ kb_install_dir }}/killbill-flyway.jar -locations=filesystem:{{ migration['dir'] }} -table={{ migration['table'] }} -url='{{ lookup('env','KILLBILL_DAO_URL') }}' -user={{ lookup('env','KILLBILL_DAO_USER') }} -password={{ lookup('env','KILLBILL_DAO_PASSWORD') }} dryRunMigrate
-  when: migration['dir'] is defined
   register: java_dry_run_migrations
   changed_when: java_dry_run_migrations.stdout_lines
   tags: migrations
 
-- debug: msg="{{ java_dry_run_migrations.stdout_lines }}"
-  when: java_dry_run_migrations.stdout_lines
-  tags: migrations
-
-- name: prompt for SQL migration
-  pause: prompt='Should I run these migrations? Enter yes or no'
-  register: should_continue
-  when: java_dry_run_migrations.stdout_lines is defined
+- debug: msg="No migration to run for {{ migration['from_tag'] }} -> {{ migration['to_tag'] }}"
+  when: java_dry_run_migrations.stdout.find("BEGIN;\nCOMMIT;") != -1
   tags: migrations
 
 - block:
-    - name: run SQL migration
-      command: java -jar {{ kb_install_dir }}/killbill-flyway.jar -locations=filesystem:{{ migration['dir'] }} -table={{ migration['table'] }} -url='{{ lookup('env','KILLBILL_DAO_URL') }}' -user={{ lookup('env','KILLBILL_DAO_USER') }} -password={{ lookup('env','KILLBILL_DAO_PASSWORD') }} migrate
-      when: migration['dir'] is defined
-      register: java_migrations
-      changed_when: java_migrations.stdout_lines
+    - debug: msg="{{ java_dry_run_migrations.stdout_lines }}"
+      when: java_dry_run_migrations.stdout_lines
       tags: migrations
 
-    - debug: msg="{{ java_migrations.stdout_lines }}"
-      when: java_migrations.stdout_lines
+    - name: prompt for SQL migration
+      pause: prompt='Should I run these migrations? Enter yes or no'
+      register: should_continue
+      when: java_dry_run_migrations.stdout_lines is defined
       tags: migrations
-  when: should_continue.user_input | bool
+
+    - block:
+        - name: run SQL migration
+          command: java -jar {{ kb_install_dir }}/killbill-flyway.jar -locations=filesystem:{{ migration['dir'] }} -table={{ migration['table'] }} -url='{{ lookup('env','KILLBILL_DAO_URL') }}' -user={{ lookup('env','KILLBILL_DAO_USER') }} -password={{ lookup('env','KILLBILL_DAO_PASSWORD') }} migrate
+          register: java_migrations
+          ignore_errors: True
+          tags: migrations
+
+        - name: fail the play if the previous command did not succeed
+          fail: msg="{{ java_migrations.stderr_lines }}"
+          when: java_migrations.rc != 0 and 'contains a failed migration'
+          tags: migrations
+
+        - debug: msg="{{ java_migrations.stdout_lines }}"
+          when: java_migrations.stdout_lines
+          tags: migrations
+      when: should_continue.user_input | bool
+  when: java_dry_run_migrations.stdout.find("BEGIN;\nCOMMIT;") == -1

--- a/ansible/roles/migrations/tasks/migrate.yml
+++ b/ansible/roles/migrations/tasks/migrate.yml
@@ -1,5 +1,5 @@
 - name: generate SQL migration
-  command: java -jar {{ kb_install_dir }}/killbill-flyway.jar -locations=filesystem:{{ migration['dir'] }} -table={{ migration['table'] }} -url='{{ lookup('env','KILLBILL_DAO_URL') }}' -user={{ lookup('env','KILLBILL_DAO_USER') }} -password={{ lookup('env','KILLBILL_DAO_PASSWORD') }} dryRunMigrate
+  command: "{{ flyway }} -locations=filesystem:{{ migration['dir'] }} -table={{ migration['table'] }} dryRunMigrate"
   register: java_dry_run_migrations
   changed_when: java_dry_run_migrations.stdout_lines
   tags: migrations
@@ -21,18 +21,27 @@
 
     - block:
         - name: run SQL migration
-          command: java -jar {{ kb_install_dir }}/killbill-flyway.jar -locations=filesystem:{{ migration['dir'] }} -table={{ migration['table'] }} -url='{{ lookup('env','KILLBILL_DAO_URL') }}' -user={{ lookup('env','KILLBILL_DAO_USER') }} -password={{ lookup('env','KILLBILL_DAO_PASSWORD') }} migrate
+          command: "{{ flyway }} -locations=filesystem:{{ migration['dir'] }} -table={{ migration['table'] }} migrate"
           register: java_migrations
           ignore_errors: True
           tags: migrations
 
-        - name: fail the play if the previous command did not succeed
-          fail: msg="{{ java_migrations.stderr_lines }}"
-          when: java_migrations.rc != 0 and 'contains a failed migration'
-          tags: migrations
-
         - debug: msg="{{ java_migrations.stdout_lines }}"
           when: java_migrations.stdout_lines
+          tags: migrations
+
+        - debug: msg="{{ java_migrations.stderr_lines }}"
+          when: java_migrations.stderr_lines
+          tags: migrations
+
+        - name: fail the play if the schema_version table is corrupted
+          fail: msg="schema_version corrupted. Try running {{ flyway }} -locations=filesystem:{{ migration['dir'] }} -table={{ migration['table'] }} repair"
+          when: java_migrations.rc != 0 and 'contains a failed migration' in java_migrations.stderr
+          tags: migrations
+
+        - name: fail the play if the migrations did not succeed
+          fail: msg="Migrations failed. You need to fix the tables, adjust the schema_version table manually (i.e. insert a line for that migration or update the status to success) and run {{ flyway }} -locations=filesystem:{{ migration['dir'] }} -table={{ migration['table'] }} repair"
+          when: java_migrations.rc != 0 and 'contains a failed migration' not in java_migrations.stderr
           tags: migrations
       when: should_continue.user_input | bool
   when: java_dry_run_migrations.stdout.find("BEGIN;\nCOMMIT;") == -1

--- a/ansible/roles/migrations/tasks/migrate.yml
+++ b/ansible/roles/migrations/tasks/migrate.yml
@@ -1,0 +1,29 @@
+- name: generate SQL migration
+  command: java -jar {{ kb_install_dir }}/killbill-flyway.jar -locations=filesystem:{{ migration['dir'] }} -table={{ migration['table'] }} -url='{{ lookup('env','KILLBILL_DAO_URL') }}' -user={{ lookup('env','KILLBILL_DAO_USER') }} -password={{ lookup('env','KILLBILL_DAO_PASSWORD') }} dryRunMigrate
+  when: migration['dir'] is defined
+  register: java_dry_run_migrations
+  changed_when: java_dry_run_migrations.stdout_lines
+  tags: migrations
+
+- debug: msg="{{ java_dry_run_migrations.stdout_lines }}"
+  when: java_dry_run_migrations.stdout_lines
+  tags: migrations
+
+- name: prompt for SQL migration
+  pause: prompt='Should I run these migrations? Enter yes or no'
+  register: should_continue
+  when: java_dry_run_migrations.stdout_lines is defined
+  tags: migrations
+
+- block:
+    - name: run SQL migration
+      command: java -jar {{ kb_install_dir }}/killbill-flyway.jar -locations=filesystem:{{ migration['dir'] }} -table={{ migration['table'] }} -url='{{ lookup('env','KILLBILL_DAO_URL') }}' -user={{ lookup('env','KILLBILL_DAO_USER') }} -password={{ lookup('env','KILLBILL_DAO_PASSWORD') }} migrate
+      when: migration['dir'] is defined
+      register: java_migrations
+      changed_when: java_migrations.stdout_lines
+      tags: migrations
+
+    - debug: msg="{{ java_migrations.stdout_lines }}"
+      when: java_migrations.stdout_lines
+      tags: migrations
+  when: should_continue.user_input | bool

--- a/kpm/lib/kpm/plugins_directory.rb
+++ b/kpm/lib/kpm/plugins_directory.rb
@@ -19,7 +19,6 @@ module KPM
       all(latest).inject({}) { |out, (key, val)| out[key]=val[:versions][kb_version.to_sym] if val[:versions].key?(kb_version.to_sym) ; out}
     end
 
-    # Note: this API is used in Docker images (see kpm_generator.rb, careful when changing it!)
     def self.lookup(raw_plugin_key, latest=false, raw_kb_version=nil)
       plugin_key = raw_plugin_key.to_s.downcase
       plugin = all(latest)[plugin_key.to_sym]


### PR DESCRIPTION
Wraps `killbill-flyway` and `kpm migrations` in an Ansible playbook. It is never automatically invoked though, it is expected to be run manually.

Work still in progress:

* General cleanup of our Ansible roles and better errors handling
* Update our Docker images to support this
* Update `killbill-docs`