### PR TITLE
Flyway support in Docker

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -58,14 +58,14 @@ Example playbook on how to install Tomcat (Java is a pre-requisite):
 ansible-playbook -i <HOST_FILE> tomcat.yml
 ```
 
-## flyway.yml playbook
+## migrations.yml playbook
 
-Playbook to manage Kill Bill (and its plugins) migrations.
+Playbook to manage Kill Bill (and its plugins) database migrations.
 
 Assuming Kill Bill is installed locally (`/var/lib/tomcat/webapps/ROOT.war` by default) and your `kpm.yml` (`/var/lib/killbill/kpm.yml` by default) points to the **new** version of Kill Bill:
 
 ```
-ansible-playbook -i localhost, -e ansible_connection=local -e gh_token=XXX flyway.yml
+ansible-playbook -i localhost, -e ansible_connection=local -e gh_token=XXX migrations.yml
 ```
 
 This will install Flyway, fetch all migrations and prompt the user whether they should be applied.

--- a/ansible/flyway.yml
+++ b/ansible/flyway.yml
@@ -1,7 +1,10 @@
 ---
-- name: Flyway migrations
+- name: Install Flyway
   hosts: all
-  roles:
-    - common
-    - kpm
-    - migrations
+  tasks:
+    - name: setup Ruby
+      import_tasks: roles/common/tasks/main.yml
+    - name: setup KPM
+      import_tasks: roles/kpm/tasks/main.yml
+    - name: install Flyway
+      import_tasks: roles/migrations/tasks/flyway.yml

--- a/ansible/kaui.yml
+++ b/ansible/kaui.yml
@@ -2,12 +2,6 @@
 - name: Deploy Kaui
   hosts: all
   vars:
-    catalina_base: /var/lib/tomcat
-    tomcat_owner: tomcat
-    tomcat_group: tomcat
-    kpm_install_dir: /opt
-    kpm_version: 0.6.2
-    kpm_path: "{{ kpm_install_dir }}/kpm-{{ kpm_version }}-linux-{{ ansible_architecture }}"
     kpm_yml: /var/lib/kaui/kpm.yml
   tasks:
     - name: setup Ruby

--- a/ansible/killbill.yml
+++ b/ansible/killbill.yml
@@ -1,16 +1,6 @@
 ---
 - name: Deploy Kill Bill
   hosts: all
-  vars:
-    catalina_base: /var/lib/tomcat
-    tomcat_owner: tomcat
-    tomcat_group: tomcat
-    kpm_install_dir: /opt
-    kpm_version: 0.6.2
-    kpm_path: "{{ kpm_install_dir }}/kpm-{{ kpm_version }}-linux-{{ ansible_architecture }}"
-    kpm_yml: /var/lib/killbill/kpm.yml
-    kb_config_dir: /var/lib/killbill
-    kb_plugins_dir: /var/lib/killbill/bundles
   tasks:
     - name: setup Ruby
       import_tasks: roles/common/tasks/main.yml

--- a/ansible/kpm.yml
+++ b/ansible/kpm.yml
@@ -1,12 +1,6 @@
 ---
 - name: Deploy KPM
   hosts: all
-  vars:
-    kpm_install_dir: /opt
-    nexus_url: https://oss.sonatype.org
-    nexus_repository: releases
-    kpm_version: 0.6.2
-    kpm_path: "{{ kpm_install_dir }}/kpm-{{ kpm_version }}-linux-{{ ansible_architecture }}"
   become: yes
   tasks:
     - name: setup

--- a/ansible/library/killbill_facts
+++ b/ansible/library/killbill_facts
@@ -1,8 +1,10 @@
 #!/usr/bin/ruby
 # WANT_JSON
 
-require 'pathname'
 require 'json'
+require 'pathname'
+require 'set'
+require 'yaml'
 
 data = {}
 File.open(ARGV[0]) do |fh|
@@ -22,10 +24,14 @@ kpm_facts = KPM::System.new.information(data['bundles_dir'],
                                         data['kaui_web_path'],
                                         data['killbill_web_path'])
 
+versions_info = KPM::KillbillServerArtifact.info(data['version'],
+                                                 data['overrides'],
+                                                 data['ssl_verify'])
 result = {
   'changed' => false,
   'ansible_facts' => {
-    'kpm' => JSON.parse(kpm_facts)
+    'kpm' => JSON.parse(kpm_facts),
+    'versions_info' => versions_info
   }
 }
 

--- a/ansible/library/killbill_migrations
+++ b/ansible/library/killbill_migrations
@@ -4,6 +4,7 @@
 require 'json'
 require 'pathname'
 require 'set'
+require 'yaml'
 
 data = {}
 File.open(ARGV[0]) do |fh|
@@ -23,10 +24,8 @@ kpm_facts = KPM::System.new.information(data['bundles_dir'],
                                         data['kaui_web_path'],
                                         data['killbill_web_path'])
 
-require 'json'
 kpm_facts = JSON.parse(kpm_facts)
 
-require 'yaml'
 kpm_yml = data['kpm_yml']
 if kpm_yml.is_a?(String)
   kpm_yml = YAML::load_file(data['kpm_yml'])

--- a/ansible/migrations.yml
+++ b/ansible/migrations.yml
@@ -1,0 +1,7 @@
+---
+- name: Database migrations
+  hosts: all
+  roles:
+    - common
+    - kpm
+    - migrations

--- a/ansible/roles/migrations/tasks/flyway.yml
+++ b/ansible/roles/migrations/tasks/flyway.yml
@@ -1,0 +1,39 @@
+---
+- name: ensure Flyway install dir exists
+  become: true
+  file: path={{ flyway_install_dir }} state=directory owner={{ tomcat_owner }} group={{ tomcat_group }}
+  tags: migrations
+
+# Note: we don't check the version but the binary is rarely updated
+- name: check if Flyway is already installed
+  stat:
+    path: "{{ flyway_install_dir }}/killbill-flyway.jar"
+  register: flyway_bin
+  tags: migrations
+
+- block:
+    - name: resolve LATEST version
+      killbill_facts:
+        kpm_path: "{{ kpm_path }}"
+        bundles_dir: "{{ kb_plugins_dir }}"
+        kaui_web_path: "{{ catalina_base }}/webapps/ROOT.war"
+        killbill_web_path: "{{ catalina_base }}/webapps/ROOT.war"
+        version: LATEST
+      register: kb_facts
+      when: flyway_version is undefined
+      tags: migrations
+
+    - name: set flyway_version
+      set_fact:
+        flyway_version: "{{ kb_facts['ansible_facts']['versions_info']['killbill'] }}"
+      when: flyway_version is undefined
+      tags: migrations
+
+    - name: install Flyway
+      # maven_artifact module requires xml on the host
+      get_url:
+        url: "{{ nexus_url }}/content/repositories/{{ nexus_repository }}/org/kill-bill/billing/killbill-util/{{ flyway_version }}/killbill-util-{{ flyway_version }}-flyway.jar"
+        dest: "{{ flyway_install_dir }}/killbill-flyway.jar"
+      tags: migrations
+  when: flyway_bin.stat.exists == False
+  tags: migrations

--- a/ansible/roles/migrations/tasks/main.yml
+++ b/ansible/roles/migrations/tasks/main.yml
@@ -10,17 +10,9 @@
   register: migrations
   tags: migrations
 
-- name: ensure Flyway install dir exists
-  become: true
-  file: path={{ flyway_install_dir }} state=directory owner={{ tomcat_owner }} group={{ tomcat_group }}
-  tags: migrations
-
-- name: install Flyway
-  # maven_artifact module requires xml on the host
-  get_url:
-    url: "{{ nexus_url }}/content/repositories/{{ nexus_repository }}/org/kill-bill/billing/killbill-util/{{ migrations['migrations']['from'] }}/killbill-util-{{ migrations['migrations']['from'] }}-flyway.jar"
-    dest: "{{ flyway_install_dir }}/killbill-flyway.jar"
-  tags: migrations
+- include_tasks: flyway.yml
+  vars:
+    flyway_version: "{{ migrations['migrations']['from'] }}"
 
 - name: generate Flyway baseline tables
   command: "{{ flyway }} -locations=filesystem:{{ item['dir'] }} -table={{ item['table'] }} baseline"

--- a/docker/templates/killbill/latest/Dockerfile
+++ b/docker/templates/killbill/latest/Dockerfile
@@ -27,5 +27,20 @@ ENV KPM_INSTALL_CMD ansible-playbook $ANSIBLE_OPTS  \
                                      -e tomcat_group=$TOMCAT_GROUP \
                                      -e catalina_base=$CATALINA_BASE \
                                      $KILLBILL_CLOUD_ANSIBLE_ROLES/killbill.yml
+
+ENV MIGRATIONS_CMD ansible-playbook $ANSIBLE_OPTS \
+                                    -e kpm_install_dir=$KPM_INSTALL_DIR \
+                                    -e kpm_version=$KPM_VERSION \
+                                    -e kpm_yml=$KILLBILL_INSTALL_DIR/kpm.yml \
+                                    -e kb_config_dir=$KILLBILL_INSTALL_DIR \
+                                    -e kb_plugins_dir=$KILLBILL_INSTALL_DIR/bundles \
+                                    -e tomcat_owner=$TOMCAT_OWNER \
+                                    -e tomcat_group=$TOMCAT_GROUP \
+                                    -e catalina_base=$CATALINA_BASE \
+                                    $KILLBILL_CLOUD_ANSIBLE_ROLES/migrations.yml
+
+# Install Flyway in the image
+RUN ansible-playbook $ANSIBLE_OPTS $KILLBILL_CLOUD_ANSIBLE_ROLES/flyway.yml
+
 # Run kpm install and start Tomcat
 CMD ["/var/lib/killbill/killbill.sh"]

--- a/docker/templates/killbill/latest/kpm.yml
+++ b/docker/templates/killbill/latest/kpm.yml
@@ -1,6 +1,6 @@
 ---
 killbill:
-  version: 0.20.0
+  version: LATEST
   plugins:
     ruby:
     - name: kpm


### PR DESCRIPTION
Flyway is now installed in `killbill/killbill:latest` by default. Migrations can be run simply by invoking `$MIGRATIONS_CMD`.