### PR TITLE
Added support for reverse proxy

### DIFF
--- a/ansible/templates/tomcat/conf/server.xml.j2
+++ b/ansible/templates/tomcat/conf/server.xml.j2
@@ -34,6 +34,10 @@
                pattern="%h %l %u %t &quot;%m %U&quot; %s %b %D" />
 
         <Valve className="org.apache.catalina.valves.rewrite.RewriteValve" />
+
+        <Valve className="org.apache.catalina.valves.RemoteIpValve"
+               protocolHeader="x-forwarded-proto"
+               portHeader="x-forwarded-port" />
       </Host>
     </Engine>
   </Service>


### PR DESCRIPTION
The previous discussion https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/killbilling-users/JSmilPR1csk/D9RBlXfMCAAJ

Usage example:
```yml
    environment:
        - KILLBILL_TOMCAT_PROXY_NAME=my-killbill.domain
        - KILLBILL_TOMCAT_PROXY_PORT=443
        - KILLBILL_TOMCAT_SCHEME=https
```
Questions:
- Do these variables have to be added to [README.adoc](https://github.com/killbill/killbill-cloud/blob/master/docker/README.adoc) despite they don't have defaults?
- How can I build the image and test this PR?
