### PR TITLE
ansible: skip validations before migration

### DIFF
--- a/ansible/roles/migrations/tasks/migrate.yml
+++ b/ansible/roles/migrations/tasks/migrate.yml
@@ -21,7 +21,7 @@
 
     - block:
         - name: run SQL migration
-          command: "{{ flyway }} -locations=filesystem:{{ migration['dir'] }} -table={{ migration['table'] }} migrate"
+          command: "{{ flyway }} -locations=filesystem:{{ migration['dir'] }} -table={{ migration['table'] }} -validateOnMigrate=false migrate"
           register: java_migrations
           ignore_errors: True
           tags: migrations


### PR DESCRIPTION
If existing migrations have already been applied, Flyway will by default validate all of them before migrating.

Our Ansible playbook however only downloads the delta of migrations to run, not the full history: so if there are existing migrations, the playbook would fail.

Flyway has a flag `ignoreMissingMigrations` since 4.1.0, but our binary is still based on 4.0 and upgrading it is quite hard unfortunately.

Luckily `validateOnMigrate` skips that validation as well, so it offers a good workaround for now.
