### PR TITLE
Add missing KAUI_ROOT_USERNAME docker env var (as documented)

### DIFF
--- a/ansible/templates/kaui/conf/setenv2.sh.j2
+++ b/ansible/templates/kaui/conf/setenv2.sh.j2
@@ -21,4 +21,7 @@ export CATALINA_OPTS="$CATALINA_OPTS
 {% if lookup('env', 'KAUI_CONFIG_DAO_USER') %}
                       -Dkaui.db.username={{ lookup('env', 'KAUI_CONFIG_DAO_USER') }}
 {% endif %}
+{% if lookup('env', 'KAUI_ROOT_USERNAME') %}
+                      -Dkaui.root_username={{ lookup('env', 'KAUI_ROOT_USERNAME') }}
+{% endif %}
                       {{ kaui_system_properties }}"

--- a/docker/README.adoc
+++ b/docker/README.adoc
@@ -208,6 +208,7 @@ The following environment variables will populate the default `killbill.properti
 * `KAUI_CONFIG_DAO_USER` (default `kaui`)
 * `KAUI_CONFIG_DAO_PASSWORD` (default `kaui`)
 * `KAUI_CONFIG_DEMO` (default `false`)
+* `KAUI_ROOT_USERNAME` (default `admin`)
 
 For PostgreSQL support, you also need to specify `KAUI_CONFIG_DAO_ADAPTER=postgresql`.
 


### PR DESCRIPTION
In https://docs.killbill.io/latest/user_management.html#_super_user the `KAUI_ROOT_USERNAME` docker env var is documented to map to the `kaui.root_username` system property, but it looks like that's missing: https://github.com/search?q=org%3Akillbill+KAUI_ROOT_USERNAME&type=Code

I've added it along side the other KAUI docker env vars.