### PR TITLE
kpm: Cloudsmith download fix

### DIFF
--- a/.github/workflows/kpm_ci.yml
+++ b/.github/workflows/kpm_ci.yml
@@ -1,0 +1,87 @@
+name: kpm_ci
+
+on: [push, pull_request, workflow_dispatch]
+
+env:
+  JRUBY_OPTS: --2.0 -J-Xmx1024M
+  KB_ADDRESS: 0.0.0.0
+  KB_PORT: 8080
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # JRuby 9.1 has a bug with Bundler 2 (https://github.com/ruby/setup-ruby/issues/108), using Bundler 1 will trigger tgz errors
+        # ruby-version: ['2.4.2', 'jruby-9.1.17.0']
+        ruby-version: ['2.4.2']
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+          working-directory: kpm
+      - name: Start stack
+        run: |
+          cd kpm/docker && docker-compose -p it -f docker-compose.ci.mysql.yml up -d
+      - name: Wait for stack
+        run: |
+          count=0
+          until $(curl --output /dev/null --silent --fail http://${KB_ADDRESS}:${KB_PORT}/1.0/healthcheck); do
+            if [[ "$count" == "180" ]]; then
+              exit 64
+            fi
+            count=$(( count + 1 ))
+            sleep 1
+          done
+          curl -v \
+               -X POST \
+               -u admin:password \
+               -H 'Content-Type: application/json' \
+               -H 'X-Killbill-CreatedBy: GitHub' \
+               -d '{"apiKey": "bob", "apiSecret": "lazar"}' \
+               "http://${KB_ADDRESS}:${KB_PORT}/1.0/kb/tenants?useGlobalDefault=true"
+          mysql -uroot -proot -h 0.0.0.0 -e "CREATE USER 'test_user'@'%' IDENTIFIED BY 'test_password'; GRANT ALL PRIVILEGES ON *.* TO 'test_user'@'%'; FLUSH PRIVILEGES;"
+      - name: Run unit tests
+        run: |
+          cd kpm
+          bundle exec rake test:spec
+      - name: Run remote tests
+        env:
+          CLOUDSMITH_ORG: ${{ secrets.CLOUDSMITH_ORG }}
+          CLOUDSMITH_REPO: ${{ secrets.CLOUDSMITH_REPO }}
+          CLOUDSMITH_TOKEN: ${{ secrets.CLOUDSMITH_TOKEN }}
+          TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          cd kpm
+          bundle exec rake test:remote:spec
+      - name: Run MySQL tests
+        run: |
+          cd kpm
+          bundle exec rake test:mysql:spec
+      - name: Debugging after failure
+        if: failure()
+        run: |
+          echo "[DEBUG] killbill healthcheck"
+          curl -v http://${KB_ADDRESS}:${KB_PORT}/1.0/healthcheck || true
+          echo "[DEBUG] hostname"
+          hostname
+          echo "[DEBUG] netstat -tulpn"
+          sudo netstat -tulpn
+          echo "[DEBUG] docker network ls"
+          docker network ls
+          echo "[DEBUG] docker ps -a"
+          docker ps -a
+          echo "[DEBUG] killbill env"
+          docker exec it_killbill_1 env || true
+          echo "[DEBUG] db env"
+          docker exec it_db_1 env || true
+          echo "[DEBUG] killbill logs"
+          docker logs --details it_killbill_1 || true
+          echo "[DEBUG] killbill raw logs"
+          sudo cat /tmp/it/logs/killbill.out || true
+          echo "[DEBUG] db logs"
+          docker logs --details it_db_1 || true

--- a/.github/workflows/kpm_rubocop.yml
+++ b/.github/workflows/kpm_rubocop.yml
@@ -1,0 +1,19 @@
+name: kpm_rubocop
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  kpm_rubocop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.4.2
+          bundler-cache: true
+          working-directory: kpm
+      - name: Run RuboCop
+        run: |
+          cd kpm
+          bundle exec rubocop --parallel

--- a/kpm/docker/docker-compose.ci.mysql.yml
+++ b/kpm/docker/docker-compose.ci.mysql.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+
+services:
+  killbill:
+    network_mode: host
+    image: killbill/killbill:0.22.1
+    environment:
+      - KILLBILL_CATALOG_URI=SpyCarAdvanced.xml
+      - KILLBILL_DAO_URL=jdbc:mysql://0.0.0.0:3306/killbill
+      - KILLBILL_DAO_USER=root
+      - KILLBILL_DAO_PASSWORD=root
+      - KILLBILL_SERVER_TEST_MODE=true
+      - KILLBILL_INVOICE_SANITY_SAFETY_BOUND_ENABLED=false
+      - KILLBILL_INVOICE_MAX_DAILY_NUMBER_OF_ITEMS_SAFETY_BOUND=-1
+    depends_on:
+      - db
+  db:
+    network_mode: host
+    image: killbill/mariadb:0.22
+    environment:
+      - MYSQL_ROOT_PASSWORD=root

--- a/kpm/lib/kpm/nexus_helper/cloudsmith_api_calls.rb
+++ b/kpm/lib/kpm/nexus_helper/cloudsmith_api_calls.rb
@@ -9,7 +9,11 @@ module KPM
   module NexusFacade
     class CloudsmithApiCalls < NexusApiCallsV2
       def pull_artifact_endpoint(coordinates)
-        version_artifact_details = parent_get_artifact_info(coordinates) rescue ''
+        version_artifact_details = begin
+                                     parent_get_artifact_info(coordinates)
+                                   rescue StandardError
+                                     ''
+                                   end
 
         # For SNAPSHOTs, we need to figure out the version used as part of the filename
         filename_version = begin

--- a/kpm/lib/kpm/nexus_helper/cloudsmith_api_calls.rb
+++ b/kpm/lib/kpm/nexus_helper/cloudsmith_api_calls.rb
@@ -9,7 +9,7 @@ module KPM
   module NexusFacade
     class CloudsmithApiCalls < NexusApiCallsV2
       def pull_artifact_endpoint(coordinates)
-        version_artifact_details = parent_get_artifact_info(coordinates)
+        version_artifact_details = parent_get_artifact_info(coordinates) rescue ''
 
         # For SNAPSHOTs, we need to figure out the version used as part of the filename
         filename_version = begin
@@ -27,8 +27,6 @@ module KPM
 
       alias parent_get_artifact_info get_artifact_info
       def get_artifact_info(coordinates)
-        super
-
         _, versioned_artifact, coords = build_base_path_and_coords(coordinates)
         sha1 = get_sha1(coordinates)
         "<artifact-resolution>

--- a/kpm/spec/kpm/remote/cloudsmith_api_calls_spec.rb
+++ b/kpm/spec/kpm/remote/cloudsmith_api_calls_spec.rb
@@ -24,17 +24,65 @@ describe KPM::NexusFacade, skip_me_if_nil: ENV['CLOUDSMITH_TOKEN'].nil? do
     expect { nexus_remote.search_for_artifacts(coordinates) }.to raise_exception(NoMethodError, 'Cloudsmith has no search support')
   }
 
-  it {
-    response = nil
-    expect { response = nexus_remote.get_artifact_info(coordinates) }.not_to raise_exception
-    expect(REXML::Document.new(response).elements['//version'].text).to eq(coordinates_map[:version])
-  }
+  context 'when pulling release artifact' do
+    let(:coordinates_map) do
+      { version: '1.2.3',
+        group_id: 'com.mycompany.app',
+        artifact_id: 'my-app',
+        packaging: 'pom',
+        classifier: nil }
+    end
+    let(:coordinates) { KPM::Coordinates.build_coordinates(coordinates_map) }
 
-  it {
-    response = nil
-    destination = Dir.mktmpdir('artifact')
-    expect { response = nexus_remote.pull_artifact(coordinates, destination) }.not_to raise_exception
-    destination = File.join(File.expand_path(destination), response[:file_name])
-    expect(File.read(destination)).to match(/org.kill-bill.billing/)
-  }
+    it {
+      response = nil
+      expect { response = nexus_remote.get_artifact_info(coordinates) }.not_to raise_exception
+      parsed_doc = REXML::Document.new(response)
+      expect(parsed_doc.elements['//version'].text).to eq('1.2.3')
+      expect(parsed_doc.elements['//repositoryPath'].text).to eq('/com/mycompany/app/1.2.3/my-app-1.2.3.pom')
+      expect(parsed_doc.elements['//snapshot'].text).to eq('false')
+    }
+
+    it {
+      response = nil
+      destination = Dir.mktmpdir('artifact')
+      expect { response = nexus_remote.pull_artifact(coordinates, destination) }.not_to raise_exception
+      destination = File.join(File.expand_path(destination), response[:file_name])
+      parsed_pom = REXML::Document.new(File.read(destination))
+      expect(parsed_pom.elements['//groupId'].text).to eq('com.mycompany.app')
+      expect(parsed_pom.elements['//artifactId'].text).to eq('my-app')
+      expect(parsed_pom.elements['//version'].text).to eq('1.2.3')
+    }
+  end
+
+  context 'when pulling SNAPSHOT artifact' do
+    let(:coordinates_map) do
+      { version: '1.2.4-SNAPSHOT',
+        group_id: 'com.mycompany.app',
+        artifact_id: 'my-app',
+        packaging: 'pom',
+        classifier: nil }
+    end
+    let(:coordinates) { KPM::Coordinates.build_coordinates(coordinates_map) }
+
+    it {
+      response = nil
+      expect { response = nexus_remote.get_artifact_info(coordinates) }.not_to raise_exception
+      parsed_doc = REXML::Document.new(response)
+      expect(parsed_doc.elements['//version'].text).to eq('1.2.4-SNAPSHOT')
+      expect(parsed_doc.elements['//repositoryPath'].text).to eq('/com/mycompany/app/1.2.4-SNAPSHOT/my-app-1.2.4-SNAPSHOT.pom')
+      expect(parsed_doc.elements['//snapshot'].text).to eq('true')
+    }
+
+    it {
+      response = nil
+      destination = Dir.mktmpdir('artifact')
+      expect { response = nexus_remote.pull_artifact(coordinates, destination) }.not_to raise_exception
+      destination = File.join(File.expand_path(destination), response[:file_name])
+      parsed_pom = REXML::Document.new(File.read(destination))
+      expect(parsed_pom.elements['//groupId'].text).to eq('com.mycompany.app')
+      expect(parsed_pom.elements['//artifactId'].text).to eq('my-app')
+      expect(parsed_pom.elements['//version'].text).to eq('1.2.4-SNAPSHOT')
+    }
+  end
 end


### PR DESCRIPTION
Per @lskillen, don't assume a `maven-metadata.xml` exists for non-SNAPSHOT artifacts.

I've added a regression test on GitHub Actions for this, which pulls from a Cloudsmith test repository:

1. A released artifact
2. A SNAPSHOT artifact (with multiple uploads)