### PR TITLE
docker: Specify a default for mariaddb secure_file_priv

### DIFF
--- a/docker/templates/mariadb/tagged/Dockerfile.template
+++ b/docker/templates/mariadb/tagged/Dockerfile.template
@@ -28,4 +28,4 @@ RUN echo "INSERT INTO kaui.kaui_allowed_users (kb_username, description, created
 
 RUN mkdir -p /tmp/replicate
 
-CMD ["mysqld", "--secure-file-priv=/tmp/replicate"]
+CMD ["mysqld", "--secure-file-priv=/tmp"]

--- a/docker/templates/mariadb/tagged/Dockerfile.template
+++ b/docker/templates/mariadb/tagged/Dockerfile.template
@@ -26,6 +26,4 @@ RUN set -x \
 
 RUN echo "INSERT INTO kaui.kaui_allowed_users (kb_username, description, created_at, updated_at) values ('admin', 'super admin', NOW(), NOW());" > /docker-entrypoint-initdb.d/021_kaui_admin.sql
 
-RUN mkdir -p /tmp/replicate
-
 CMD ["mysqld", "--secure-file-priv=/tmp"]

--- a/docker/templates/mariadb/tagged/Dockerfile.template
+++ b/docker/templates/mariadb/tagged/Dockerfile.template
@@ -25,3 +25,7 @@ RUN set -x \
         && apt-get purge -y --auto-remove ca-certificates wget
 
 RUN echo "INSERT INTO kaui.kaui_allowed_users (kb_username, description, created_at, updated_at) values ('admin', 'super admin', NOW(), NOW());" > /docker-entrypoint-initdb.d/021_kaui_admin.sql
+
+RUN mkdir -p /tmp/replicate
+
+CMD ["mysqld", "--secure-file-priv=/tmp/replicate"]

--- a/kpm/lib/kpm/account.rb
+++ b/kpm/lib/kpm/account.rb
@@ -26,7 +26,6 @@ module KPM
     # Temporary directory
     TMP_DIR_PEFIX = 'killbill'
     TMP_DIR = Dir.mktmpdir(TMP_DIR_PEFIX)
-    BLOB_TMP_DIR = '/tmp/replicate'
 
     # Created By
     WHO = 'kpm_export_import'
@@ -387,7 +386,7 @@ module KPM
       # Verify encoded of the decoded value == input prior return result
       return input if  Base64.strict_encode64(result) != input
 
-      Blob.new(result, BLOB_TMP_DIR)
+      Blob.new(result, TMP_DIR)
     end
 
     def sniff_delimiter(file)

--- a/kpm/lib/kpm/account.rb
+++ b/kpm/lib/kpm/account.rb
@@ -26,6 +26,7 @@ module KPM
     # Temporary directory
     TMP_DIR_PEFIX = 'killbill'
     TMP_DIR = Dir.mktmpdir(TMP_DIR_PEFIX)
+    BLOB_TMP_DIR = '/tmp/replicate'
 
     # Created By
     WHO = 'kpm_export_import'
@@ -386,7 +387,7 @@ module KPM
       # Verify encoded of the decoded value == input prior return result
       return input if  Base64.strict_encode64(result) != input
 
-      Blob.new(result, TMP_DIR)
+      Blob.new(result, BLOB_TMP_DIR)
     end
 
     def sniff_delimiter(file)

--- a/kpm/lib/kpm/blob.rb
+++ b/kpm/lib/kpm/blob.rb
@@ -2,7 +2,6 @@
 
 require 'fileutils'
 
-
 module KPM
   class Blob
     def initialize(value, tmp_dir)

--- a/kpm/lib/kpm/blob.rb
+++ b/kpm/lib/kpm/blob.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+
+
 module KPM
   class Blob
     def initialize(value, tmp_dir)
       @tmp_dir = tmp_dir
       @blob_file = @tmp_dir + File::SEPARATOR + rand.to_s
+      # Make sure directory is 'rx' for others to allow LOAD_FILE to work
+      FileUtils.chmod('a+rx', tmp)
       store_value(value)
     end
 

--- a/kpm/lib/kpm/blob.rb
+++ b/kpm/lib/kpm/blob.rb
@@ -8,7 +8,7 @@ module KPM
       @tmp_dir = tmp_dir
       @blob_file = @tmp_dir + File::SEPARATOR + rand.to_s
       # Make sure directory is 'rx' for others to allow LOAD_FILE to work
-      FileUtils.chmod('a+rx', tmp)
+      FileUtils.chmod('a+rx', @tmp_dir)
       store_value(value)
     end
 


### PR DESCRIPTION
* In order to be able to LOAD_FILE, we need to configure the `mysqld` with the path of where such files can be loaded. See https://github.com/killbill/killbill-cloud/pull/194/commits/4ca955902ab2cdc7b81d0df280c46698b84796d5
* KPM account needs to be updated to use this temp location: https://github.com/killbill/killbill-cloud/pull/194/commits/934ff38aa62b355e84b1c5931f05d116be1a22db