### PR TITLE
kpm: update rubyzip to 1.3.0

### DIFF
--- a/kpm/kpm.gemspec
+++ b/kpm/kpm.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'highline', '~> 1.6.21'
   s.add_dependency 'killbill-client', '~> 3.2'
-  s.add_dependency 'rubyzip', '~>1.2.0'
+  s.add_dependency 'rubyzip', '~> 1.3.0'
   s.add_dependency 'thor', '~> 0.19.1'
 
   s.add_development_dependency 'gem-release', '~> 2.2'


### PR DESCRIPTION
This addresses CVE-2019-16892.
