### PR TITLE
ansible: generate placeholder killbill.properties

### DIFF
--- a/ansible/roles/killbill/tasks/main.yml
+++ b/ansible/roles/killbill/tasks/main.yml
@@ -7,6 +7,21 @@
     - "{{ kb_plugins_dir }}"
   tags: kpm-install
 
+# Generate Kill Bill placeholder configuration files
+- name: generate Kill Bill files
+  become: true
+  template:
+    src: "killbill/{{ item.name }}.j2"
+    dest: "{{ kb_config_dir }}/{{ item.name }}"
+    mode: u=rw,g=r,o=r
+    owner: "{{ tomcat_owner }}"
+    group: "{{ tomcat_group }}"
+    # If the files already exist, don't clobber them
+    force: no
+  with_items:
+    - name: killbill.properties
+  tags: kpm-install
+
 - name: generate kpm.yml file if needed
   become: true
   template:

--- a/ansible/templates/killbill/killbill.properties.j2
+++ b/ansible/templates/killbill/killbill.properties.j2
@@ -1,0 +1,1 @@
+# Placeholder


### PR DESCRIPTION
This gets rid of a warning at startup.
