### PR TITLE
docker: lock KPM version for 0.22.x

### DIFF
--- a/docker/templates/base/latest/Dockerfile
+++ b/docker/templates/base/latest/Dockerfile
@@ -65,6 +65,7 @@ ENV ANSIBLE_OPTS="-i localhost, \
                   -e ansible_connection=local \
                   -e ansible_python_interpreter=/usr/bin/python3 \
                   -e java_home=$JAVA_HOME \
+                  -e kpm_version=0.10.4 \
                   -vv"
 
 # Install KPM

--- a/docker/templates/kaui/latest/Dockerfile
+++ b/docker/templates/kaui/latest/Dockerfile
@@ -14,7 +14,6 @@ COPY ./kaui.sh $KAUI_INSTALL_DIR
 
 ENV KPM_INSTALL_CMD="ansible-playbook $ANSIBLE_OPTS  \
                                       -e kpm_install_dir=$KPM_INSTALL_DIR \
-                                      -e kpm_version=$KPM_VERSION \
                                       -e kpm_yml=$KAUI_INSTALL_DIR/kpm.yml \
                                       -e tomcat_owner=$TOMCAT_OWNER \
                                       -e tomcat_group=$TOMCAT_GROUP \


### PR DESCRIPTION
KPM 0.11.0 is incompatible with Kill Bill 0.22.x, make sure to pin the version in `master`.

Related: https://github.com/killbill/killbill-cloud/pull/213