### PR TITLE
Added a task to remove JRuby jar from default bundle to fix the KPM issue

### DIFF
--- a/ansible/roles/killbill/tasks/main.yml
+++ b/ansible/roles/killbill/tasks/main.yml
@@ -126,3 +126,11 @@
     path: "{{ catalina_base }}/{{ kb_webapps }}/ROOT.war"
     state: absent
   tags: killbill-logback
+
+- name: Remove JRuby jar to fix KPM
+  # See https://github.com/killbill/killbill-cloud/pull/218
+  file:
+    state: absent
+    path: /var/lib/killbill/bundles/platform/killbill-platform-osgi-bundles-jruby-0.40.12.jar
+  tags:
+    - kpm


### PR DESCRIPTION
Log snippet:

```
<ec2-54-152-18-140.compute-1.amazonaws.com> (0, '', '')
changed: [ec2-54-152-18-140.compute-1.amazonaws.com] => {
    "changed": true, 
    "diff": {
        "after": {
            "path": "/var/lib/killbill/bundles/platform/killbill-platform-osgi-bundles-jruby-0.40.12.jar", 
            "state": "absent"
        }, 
        "before": {
            "path": "/var/lib/killbill/bundles/platform/killbill-platform-osgi-bundles-jruby-0.40.12.jar", 
            "state": "file"
        }
    }, 
```

![CF_KPM_Working](https://user-images.githubusercontent.com/12543246/178007781-2c034ebd-2beb-4969-9ce0-242eb9b80cf5.PNG)
