### PR TITLE
Updated catalog plugin test version

### DIFF
--- a/kpm/lib/kpm/plugins_directory.yml
+++ b/kpm/lib/kpm/plugins_directory.yml
@@ -96,7 +96,7 @@
 :catalog-test:
   :type: :java
   :versions:
-    :0.24: 0.5.0
+    :0.24: 0.5.1
 :gocardless:
   :type: :java
   :versions:


### PR DESCRIPTION
Updated the `groupId` for `catalog-test-plugin` (See [PR](https://github.com/killbill/killbill-catalog-plugin-test/pull/18)). As part of this change, version `5.1` of the `catalog-test-plugin` was released. This PR updates [plugins_directory.yml](https://github.com/killbill/killbill-cloud/compare/fix-plugin-directory?expand=1#diff-0a320713fd016f25c58c4c037a16b0a62766fafba6f3a1ad96be71448c54e5d9) to point to the new version.