### PR TITLE
docker: fix database build

### DIFF
--- a/docker/dockerTemplate.sh
+++ b/docker/dockerTemplate.sh
@@ -22,7 +22,9 @@ init() {
     cat "$TAGGED_PATH/Dockerfile.template" | sed -e "s/__PARENT_VERSION__/$PARENT_VERSION/" | sed -e "s/__VERSION__/$VERSION/" > "$TAGGED_PATH/Dockerfile"
     echo "Built $TAGGED_PATH/Dockerfile with FROM:"
     grep FROM $TAGGED_PATH/Dockerfile
-    cat "$TAGGED_PATH/kpm.yml.template"  | sed -e "s/__VERSION__/$VERSION/" > "$TAGGED_PATH/kpm.yml"
+    if [[ -f "$TAGGED_PATH/kpm.yml.template" ]]; then
+        cat "$TAGGED_PATH/kpm.yml.template" | sed -e "s/__VERSION__/$VERSION/" > "$TAGGED_PATH/kpm.yml"
+    fi
   else
     cat "$LATEST_PATH/Dockerfile.template" | sed -e "s/__PARENT_VERSION__/$PARENT_VERSION/" > "$LATEST_PATH/Dockerfile"
     echo "Built $LATEST_PATH/Dockerfile with FROM:"


### PR DESCRIPTION
Fix error:

```
2023-06-21T12:20:06.0344483Z Built templates/mariadb/tagged/Dockerfile with FROM:
2023-06-21T12:20:06.0355511Z FROM mariadb
2023-06-21T12:20:06.0382128Z cat: templates/mariadb/tagged/kpm.yml.template: No such file or directory
```