### PR TITLE
docker: pin MariaDB version

### DIFF
--- a/docker/templates/mariadb/tagged/Dockerfile.template
+++ b/docker/templates/mariadb/tagged/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM mariadb
+FROM mariadb:10.11
 MAINTAINER Kill Bill core team <killbilling-users@googlegroups.com>
 
 # VERSION will be expanded in Makefile


### PR DESCRIPTION
Kaui isn't compatible with 11.0 yet.