### PR TITLE
Fix KAUI_SECRET_KEY_BASE issue

### DIFF
--- a/docker/templates/kaui/latest/setenv2.sh
+++ b/docker/templates/kaui/latest/setenv2.sh
@@ -1,6 +1,9 @@
 # Java Properties
 export CATALINA_OPTS="$CATALINA_OPTS
-                      "
+
+if [  -z ${KAUI_SECRET_KEY_BASE+x} ]; then
+  export KAUI_SECRET_KEY_BASE=$(head -c 1024 /dev/urandom | base64 | tr -cd "[:upper:][:digit:]" | head -c 129)
+fi                      "
 
 #
 # Load legacy properties (backward compatibility)
@@ -16,7 +19,4 @@ if [ ! -z ${KAUI_CONFIG_DAO_USER+x} ]; then
 fi
 if [ ! -z ${KAUI_CONFIG_DAO_PASSWORD+x} ]; then
   export KAUI_DB_PASSWORD=$KAUI_CONFIG_DAO_PASSWORD
-fi
-if [  -z ${KAUI_SECRET_KEY_BASE+x} ]; then
-  export KAUI_SECRET_KEY_BASE=$(head -c 1024 /dev/urandom | base64 | tr -cd "[:upper:][:digit:]" | head -c 129)
 fi

--- a/docker/templates/kaui/latest/setenv2.sh
+++ b/docker/templates/kaui/latest/setenv2.sh
@@ -17,6 +17,6 @@ fi
 if [ ! -z ${KAUI_CONFIG_DAO_PASSWORD+x} ]; then
   export KAUI_DB_PASSWORD=$KAUI_CONFIG_DAO_PASSWORD
 fi
-if [ ! -z ${KAUI_SECRET_KEY_BASE+x} ]; then
+if [  -z ${KAUI_SECRET_KEY_BASE+x} ]; then
   export KAUI_SECRET_KEY_BASE=$(head -c 1024 /dev/urandom | base64 | tr -cd "[:upper:][:digit:]" | head -c 129)
 fi


### PR DESCRIPTION
Currently, it is required to specify the KAUI_SECRET_KEY_BASE in the docker compose file, otherwise, Kaui does not start.  This PR attempts to fix this issue. 

Note: this change is untested. 