### PR TITLE
Fix release issue

### DIFF
--- a/docker/templates/base/latest/Dockerfile
+++ b/docker/templates/base/latest/Dockerfile
@@ -58,7 +58,7 @@ WORKDIR $TOMCAT_HOME
 # Install ansible roles dependencies
 ARG KILLBILL_CLOUD_VERSION
 RUN ansible-galaxy collection install community.general && \
-    ansible-galaxy install git+ssh://git@github.com/killbill/killbill-cloud.git,$KILLBILL_CLOUD_VERSION
+    ansible-galaxy install git+https://git@github.com/killbill/killbill-cloud.git,$KILLBILL_CLOUD_VERSION
 ENV KILLBILL_CLOUD_ANSIBLE_ROLES=$TOMCAT_HOME/.ansible/roles/killbill-cloud/ansible
 ENV ENV_HOST_IP=localhost
 ENV ANSIBLE_OPTS="-i localhost, \


### PR DESCRIPTION
The [release workflow](https://github.com/killbill/killbill-cloud/blob/e3e2c960e073fe2e703034bca926ab2ff37d52be/.github/workflows/release.yml#L55) currently [fails](https://github.com/killbill/killbill-cloud/actions/runs/8095007126) as there is an issue while cloning the repo. This PR attempts to fix this issue.