### PR TITLE
replace mariadb with mysql in the kaui config dao url

### DIFF
--- a/docker/compose/docker-compose.kb.yml
+++ b/docker/compose/docker-compose.kb.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - "9090:8080"
     environment:
-      - KAUI_CONFIG_DAO_URL=jdbc:mariadb://db:3306/kaui
+      - KAUI_CONFIG_DAO_URL=jdbc:mysql://db:3306/kaui
       - KAUI_CONFIG_DAO_USER=root
       - KAUI_CONFIG_DAO_PASSWORD=killbill
       - KAUI_KILLBILL_URL=http://killbill:8080


### PR DESCRIPTION
Fix for issue #274 
By modifying line number “24” in “docker-compose.kb.yml”
Basically, replacing this line:
- KAUI_CONFIG_DAO_URL=jdbc:mariadb://db:3306/kaui
with
- KAUI_CONFIG_DAO_URL=jdbc:mysql://db:3306/kaui

More detail is included in the group conversation [https://groups.google.com/g/killbilling-users/c/pfz59uZ8NW0](here)
