### PR TITLE
[DO NOT MERGE] docker: publish jdk17 images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           if [[ ${{ github.event.inputs.snapshot_only }} = "true" ]]; then
             TAG="killbill/base:latest-$(git rev-parse --short "$GITHUB_SHA")"
           else
-            TAG="killbill/base:latest"
+            TAG="killbill/base:jdk17"
           fi
           cd docker/templates/base/latest
           docker buildx build --push --platform=linux/arm64,linux/amd64 --no-cache -t $TAG -f Dockerfile --build-arg KILLBILL_CLOUD_VERSION=${{ github.event.inputs.cloud_version }} --build-arg NEXUS_REPOSITORY=${{ github.event.inputs.nexus_repository }} .
@@ -60,10 +60,10 @@ jobs:
             make -e TARGET=kaui -e PARENT_VERSION=latest-$(git rev-parse --short "$GITHUB_SHA") -e VERSION=latest -e IMAGE=killbill/kaui:latest-$(git rev-parse --short "$GITHUB_SHA") multi-arch
             make -e TARGET=killbill -e PARENT_VERSION=latest-$(git rev-parse --short "$GITHUB_SHA") -e VERSION=latest -e IMAGE=killbill/killbill:latest-$(git rev-parse --short "$GITHUB_SHA") multi-arch
           else
-            make -e TARGET=kaui -e VERSION=latest multi-arch
-            make -e TARGET=killbill -e VERSION=latest multi-arch
-            make -e TARGET=mariadb VERSION=$CURRENT_LTS multi-arch
-            make -e TARGET=postgresql VERSION=$CURRENT_LTS multi-arch
+            make -e TARGET=kaui -e PARENT_VERSION=jdk17 -e VERSION=latest multi-arch
+            make -e TARGET=killbill -e PARENT_VERSION=jdk17 -e VERSION=latest multi-arch
+            #make -e TARGET=mariadb VERSION=$CURRENT_LTS multi-arch
+            #make -e TARGET=postgresql VERSION=$CURRENT_LTS multi-arch
           fi
       - name: Build and push killbill image
         if: github.event.inputs.killbill_version != ''
@@ -72,7 +72,7 @@ jobs:
           if [[ ${{ github.event.inputs.snapshot_only }} = "true" ]]; then
             make -e TARGET=killbill -e PARENT_VERSION=latest-$(git rev-parse --short "$GITHUB_SHA") -e VERSION=${{ github.event.inputs.killbill_version }} -e IMAGE=killbill/killbill:${{ github.event.inputs.killbill_version }}-$(git rev-parse --short "$GITHUB_SHA") multi-arch
           else
-            make -e TARGET=killbill -e VERSION=${{ github.event.inputs.killbill_version }} multi-arch
+            make -e TARGET=killbill -e PARENT_VERSION=jdk17 -e VERSION=${{ github.event.inputs.killbill_version }} multi-arch
           fi
       - name: Build and push kaui image
         if: github.event.inputs.kaui_version != ''
@@ -81,5 +81,5 @@ jobs:
           if [[ ${{ github.event.inputs.snapshot_only }} = "true" ]]; then
             make -e TARGET=kaui -e PARENT_VERSION=latest-$(git rev-parse --short "$GITHUB_SHA") -e VERSION=${{ github.event.inputs.kaui_version }} -e IMAGE=killbill/kaui:${{ github.event.inputs.kaui_version }}-$(git rev-parse --short "$GITHUB_SHA") multi-arch
           else
-            make -e TARGET=kaui -e VERSION=${{ github.event.inputs.kaui_version }} multi-arch
+            make -e TARGET=kaui -e PARENT_VERSION=jdk17 -e VERSION=${{ github.event.inputs.kaui_version }} multi-arch
           fi

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -11,10 +11,10 @@ PARENT_VERSION?=latest
 
 VERSION?=latest
 ifeq ($(VERSION),latest)
-IMAGE=killbill/$(TARGET)
+IMAGE=killbill/$(TARGET):jdk17
 TEMPLATE=templates/$(TARGET)/latest
 else
-IMAGE=killbill/$(TARGET):$(VERSION)
+IMAGE=killbill/$(TARGET):$(VERSION)-jdk17
 TEMPLATE=templates/$(TARGET)/tagged
 endif
 

--- a/docker/templates/base/latest/Dockerfile
+++ b/docker/templates/base/latest/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:20.04 as builder-base
+FROM ubuntu:24.04 AS builder-base
 LABEL maintainer="killbilling-users@googlegroups.com"
 
 USER root
 
 ENV LC_CTYPE=en_US.UTF-8
-ENV LC_ALL=C
+ENV LC_ALL=C.UTF-8
 ENV LANG=en_US.UTF-8
 ENV PYTHONIOENCODING=utf8
 
@@ -24,7 +24,7 @@ RUN apt-get update && \
       libapr1 \
       mysql-client \
       net-tools \
-      openjdk-11-jdk-headless \
+      openjdk-17-jdk-headless \
       python3-lxml \
       sudo \
       telnet \
@@ -34,7 +34,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Configure default JAVA_HOME path
-RUN ln -s java-11-openjdk-$(dpkg --print-architecture) /usr/lib/jvm/default-java
+RUN ln -s java-17-openjdk-$(dpkg --print-architecture) /usr/lib/jvm/default-java
 ENV JAVA_HOME=/usr/lib/jvm/default-java
 ENV JSSE_HOME=$JAVA_HOME/jre/
 

--- a/docker/templates/base/latest/README.md
+++ b/docker/templates/base/latest/README.md
@@ -1,6 +1,6 @@
 # killbill/base image
 
-Shared base image with Tomcat, JDK and KPM inside Ubuntu 20.04 LTS. It also contains Ansible and our playbooks from https://github.com/killbill/killbill-cloud.
+Shared base image with Tomcat, JDK and KPM inside Ubuntu 24.04 LTS. It also contains Ansible and our playbooks from https://github.com/killbill/killbill-cloud.
 
 To build this docker image:
 


### PR DESCRIPTION
This also updates the base image to Ubuntu 24.04 LTS.

The build has been updated to use the suffix jdk17 for these images:

killbill/base:jdk17
killbill/killbill:jdk17
killbill/kaui:jdk17

killbill/killbill:0.24.10-jdk17
killbill/kaui:3.0.9-jdk17