### PR TITLE
KPM release changes for OSSRH migration

### DIFF
--- a/.github/workflows/kpm_release.yml
+++ b/.github/workflows/kpm_release.yml
@@ -54,9 +54,9 @@ jobs:
         with:
           java-version: 11
           distribution: temurin
-          server-id: ossrh-releases
-          server-username: OSSRH_USER
-          server-password: OSSRH_PASS
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
       - name: Configure settings.xml for snapshots
@@ -66,8 +66,8 @@ jobs:
           java-version: 11
           distribution: temurin
           server-id: sonatype-nexus-snapshots
-          server-username: OSSRH_USER
-          server-password: OSSRH_PASS
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
       - name: Install packages
         run: |
           sudo apt-get -yq update
@@ -135,8 +135,8 @@ jobs:
       - name: Push to Maven Central
         if: github.event.inputs.snapshot_only == 'false'
         env:
-          OSSRH_USER: ${{ secrets.OSSRH_USER }}
-          OSSRH_PASS: ${{ secrets.OSSRH_PASS }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           cd kpm
@@ -144,8 +144,8 @@ jobs:
       - name: Push to Sonatype snapshots
         if: github.event.inputs.snapshot_only == 'true'
         env:
-          OSSRH_USER: ${{ secrets.OSSRH_USER }}
-          OSSRH_PASS: ${{ secrets.OSSRH_PASS }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
         run: |
           cd kpm
           mvn ${MAVEN_FLAGS} deploy


### PR DESCRIPTION
KPM release modified for OSSRH migration. Note: `server_id` for snapshot releases is not changed. LMK if this is required. 