### PR TITLE
Replace jdbc:mariadb with jdbc:mysql

### DIFF
--- a/docker/compose/docker-compose.kb.yml
+++ b/docker/compose/docker-compose.kb.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - "9090:8080"
     environment:
-      - KAUI_CONFIG_DAO_URL=jdbc:mariadb://db:3306/kaui
+      - KAUI_CONFIG_DAO_URL=jdbc:mysql://db:3306/kaui
       - KAUI_CONFIG_DAO_USER=root
       - KAUI_CONFIG_DAO_PASSWORD=killbill
       - KAUI_KILLBILL_URL=http://killbill:8080


### PR DESCRIPTION
While working on https://github.com/killbill/technical-support/issues/259, found that the docker deployment does not work when the [docker-compose.kb.yml](https://github.com/killbill/killbill-cloud/blob/master/docker/compose/docker-compose.kb.yml) is used as is, it needs the fix in this PR.  Also found that this is a known issue and there is already a ticket for this [here](https://github.com/killbill/technical-support/issues/169). 