### PR TITLE
Removed telnet to address CVE-2026-32746 vulnerability.

### DIFF
--- a/docker/templates/base/latest/Dockerfile
+++ b/docker/templates/base/latest/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update && \
       openjdk-11-jdk-headless \
       python3-lxml \
       sudo \
-      telnet \
       unzip \
       # A bit large unfortunately (https://bugs.launchpad.net/ubuntu/+source/vim/+bug/1884583)
       vim && \

--- a/docker/templates/build/Dockerfile
+++ b/docker/templates/build/Dockerfile
@@ -34,7 +34,6 @@ RUN apt-get update && \
       python3-lxml \
       software-properties-common \
       sudo \
-      telnet \
       unzip \
       zip \
       vim && \


### PR DESCRIPTION
> AWS scanning:
> 
> Vulnerability found: [CVE-2026-32746]
> Provide an updated asset without vulnerabilities, malware, or viruses. More information about this vulnerability can be found at: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2026-32746
> 

The telnet package is installing inetutils-telnet (part of GNU inetutils)

```
dpkg -l | grep -Ei "inetutils|telnet"

ii  inetutils-telnet              2:2.5-3ubuntu4.2                  amd64        telnet client
ii  telnet                        0.17+2.5-3ubuntu4.2               all          transitional dummy package for inetutils-telnet default switch
```