### PR TITLE
add require 'cgi' ' to maven_central_api_calls.rb

### DIFF
--- a/kpm/lib/kpm/nexus_helper/maven_central_api_calls.rb
+++ b/kpm/lib/kpm/nexus_helper/maven_central_api_calls.rb
@@ -4,6 +4,7 @@ require 'net/http'
 require 'uri'
 require 'json'
 require 'rexml/document'
+require 'cgi'
 
 module KPM
   module NexusFacade


### PR DESCRIPTION
Original ticket #247 . The error logs is explained in [this comment](https://github.com/killbill/killbill-cloud/issues/247#issuecomment-5038900081).