### PR TITLE
Upgrade Java 11 -> 21 and Tomcat 9 -> 11

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -31,7 +31,7 @@ The roles can now be referenced in your playbooks via `killbill-cloud/ansible/ro
 
 Requirements:
 
-* Java must be pre-installed on the target hosts (e.g. install the openjdk-11-jdk-headless package on Ubuntu). In the rest of this documentation, we will assume `$TARGET_JAVA_HOME` points to the Java home installation on the *target* hosts (e.g. `/usr/lib/jvm/java-11-openjdk-amd64`).
+* Java must be pre-installed on the target hosts (e.g. install the openjdk-21-jdk-headless package on Ubuntu). In the rest of this documentation, we will assume `$TARGET_JAVA_HOME` points to the Java home installation on the *target* hosts (e.g. `/usr/lib/jvm/java-21-openjdk-amd64`).
 * Before installing Kill Bill and/or Kaui, KPM must be installed via the kpm.yml playbook.
 
 
@@ -189,6 +189,6 @@ In order to test, one can an inventory:
 ```
 
 ```
-> ansible-playbook -v -i localhost/inventory -e java_home=/Library/Java/JavaVirtualMachines/jdk1.8.0_171.jdk/Contents/Home  -u <user> the _playbook.yml
+> ansible-playbook -v -i localhost/inventory -e java_home=/Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home  -u <user> the _playbook.yml
 ```
 

--- a/ansible/java.yml
+++ b/ansible/java.yml
@@ -2,8 +2,8 @@
 - name: Install Java
   hosts: all
   vars:
-    java_package: openjdk-11-jdk
-    default_java_home: /usr/lib/jvm/java-11-openjdk-amd64
+    java_package: openjdk-21-jdk
+    default_java_home: /usr/lib/jvm/java-21-openjdk-amd64
     java_home: /usr/lib/jvm/default-java
   tasks:
     - name: Install Java

--- a/ansible/roles/tomcat/tasks/install.yml
+++ b/ansible/roles/tomcat/tasks/install.yml
@@ -38,14 +38,14 @@
 # We don't use the xml module to avoid a dependency on lxml
 - name: Set tomcat_version
   ansible.builtin.set_fact:
-    tomcat_version: "{{ tomcat_metadata.content | regex_findall('<version>(9.0.*)</version>', '\\1') | last }}"
+    tomcat_version: "{{ tomcat_metadata.content | regex_findall('<version>(11.0.*)</version>', '\\1') | last }}"
   when: tomcat_version is undefined
   tags: install
 
 - name: Install Tomcat
   become: true
   ansible.builtin.unarchive:
-    src: "http://archive.apache.org/dist/tomcat/tomcat-9/v{{ tomcat_version }}/bin/apache-tomcat-{{ tomcat_version }}.tar.gz"
+    src: "http://archive.apache.org/dist/tomcat/tomcat-11/v{{ tomcat_version }}/bin/apache-tomcat-{{ tomcat_version }}.tar.gz"
     remote_src: true
     dest: "{{ tomcat_install_dir }}"
     owner: "{{ tomcat_owner }}"

--- a/docker/templates/base/latest/Dockerfile
+++ b/docker/templates/base/latest/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
       libapr1 \
       mysql-client \
       net-tools \
-      openjdk-11-jdk-headless \
+      openjdk-21-jdk-headless \
       python3-lxml \
       sudo \
       unzip \
@@ -33,7 +33,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Configure default JAVA_HOME path
-RUN ln -s java-11-openjdk-$(dpkg --print-architecture) /usr/lib/jvm/default-java
+RUN ln -s java-21-openjdk-$(dpkg --print-architecture) /usr/lib/jvm/default-java
 ENV JAVA_HOME=/usr/lib/jvm/default-java
 ENV JSSE_HOME=$JAVA_HOME/jre/
 

--- a/docker/templates/build/Dockerfile
+++ b/docker/templates/build/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
       maven \
       mysql-client \
       net-tools \
-      openjdk-11-jdk-headless \
+      openjdk-21-jdk-headless \
       postgresql-client \
       python3-lxml \
       software-properties-common \
@@ -41,8 +41,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Configure default JAVA_HOME path
-RUN update-java-alternatives -s java-1.11.0-openjdk-$(dpkg --print-architecture)
-RUN rm -f /usr/lib/jvm/default-java && ln -s java-11-openjdk-$(dpkg --print-architecture) /usr/lib/jvm/default-java
+RUN update-java-alternatives -s java-1.21.0-openjdk-$(dpkg --print-architecture)
+RUN rm -f /usr/lib/jvm/default-java && ln -s java-21-openjdk-$(dpkg --print-architecture) /usr/lib/jvm/default-java
 ENV JAVA_HOME=/usr/lib/jvm/default-java
 ENV JSSE_HOME=$JAVA_HOME/jre/
 
@@ -62,7 +62,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Add extra rubies
-RUN /bin/bash -l -c "rvm install 2.2.2 && rvm install 2.4.2 && rvm install jruby-9.1.14.0"
+RUN /bin/bash -l -c "rvm install 2.2.2 && rvm install 2.4.2 && rvm install jruby-10.1.1.0"
 
 # Set killbill as the default user
 USER killbill


### PR DESCRIPTION
## Summary
- Bump the JDK installed by the Docker build/base images and the `java.yml` Ansible playbook from `openjdk-11` to `openjdk-21`.
- Bump the Tomcat version installed by the `tomcat` Ansible role from the 9.0.x line to the 11.0.x line.
- Update the stale `jruby-9.1.14.0` dev image entry to `jruby-10.1.1.0`.
- Update docs (`ansible/README.md`) to match.

## Why
`killbill-admin-ui-standalone` is moving to JRuby 10 (Java 21 minimum) and jruby-rack 2.0, which requires a Jakarta Servlet 5+ container. Tomcat 9 only implements the older `javax.servlet` API (Servlet 4.0), so it can't host that app once the Rack adapter is upgraded — this PR brings the deployment tooling in line with that requirement.

## Test plan
- [ ] Run the `tomcat.yml` / `java.yml` Ansible playbooks against a real host and confirm Tomcat 11 + JDK 21 install cleanly (network to archive.apache.org wasn't reachable from the dev sandbox, so the Tomcat 11 download URL pattern is unverified end-to-end)
- [ ] Build the `base/latest` and `build` Docker images and confirm they build successfully
- [ ] Deploy the killbill-admin-ui-standalone WAR (once its own JRuby 10 upgrade lands) to a Tomcat 11 instance built from these images

🤖 Generated with [Claude Code](https://claude.com/claude-code)